### PR TITLE
Proxy for MapConfigs

### DIFF
--- a/__tests__/services/MapConfigTransformService.test.js
+++ b/__tests__/services/MapConfigTransformService.test.js
@@ -81,10 +81,16 @@ describe('MapConfigTransfrormService', function() {
     assert.equal(JSON.stringify(result), JSON.stringify(expected));
   });
   describe('has proxy', function() {
-    it('transforms MapBox source correctly', function() {
+    it('transforms WMS source correctly', function() {
       var config = {'sources':{'1':{'ptype':'gxp_wmscsource','projection':'EPSG:102113', 'url': 'http://demo.geonode.org/geoserver/wms'}},'map':{'projection':'EPSG:102113','layers':[{'source':'1','name':'Demo','title':'Demo','visibility':true,'opacity':1,'group':'','fixed':false,'selected':true}],'center':[0,0],'zoom':3}};
       var result = MapConfigTransformService.transform(config, 'http://proxy.com/?url=');
       var expected = {'layers':[{'properties':{'isRemovable':true,'visible':true,'title':'Demo','id':'Demo','name':'Demo','popupInfo':'#AllAttributes'},'type':'Tile','source':{'type':'TileWMS','properties':{'crossOrigin':'anonymous','params':{'LAYERS':'Demo','TILED':'TRUE'},'url':'http://proxy.com/?url=http://demo.geonode.org/geoserver/wms'}}}],'view':{'center':[0,0],'projection':'EPSG:102113','zoom':3}};
+      assert.equal(JSON.stringify(result), JSON.stringify(expected));
+    });
+    it('transforms WMS source with multiple layers of the same source correctly', function() {
+      var config = {'sources':{'1':{'ptype':'gxp_wmscsource','projection':'EPSG:102113', 'url': 'http://demo.geonode.org/geoserver/wms'}},'map':{'projection':'EPSG:102113','layers':[{'source':'1','name':'secondlayer','title':'Second Demo','visibility':true,'opacity':1,'group':'','fixed':false,'selected':true},{'source':'1','name':'Demo','title':'Demo','visibility':true,'opacity':1,'group':'','fixed':false,'selected':true}],'center':[0,0],'zoom':3}};
+      var result = MapConfigTransformService.transform(config, 'http://proxy.com/?url=');
+      var expected = {'layers':[{'properties':{'isRemovable':true,'visible':true,'title':'Second Demo','id':'secondlayer','name':'secondlayer','popupInfo':'#AllAttributes'},'type':'Tile','source':{'type':'TileWMS','properties':{'crossOrigin':'anonymous','params':{'LAYERS':'secondlayer','TILED':'TRUE'},'url':'http://proxy.com/?url=http://demo.geonode.org/geoserver/wms'}}},{'properties':{'isRemovable':true,'visible':true,'title':'Demo','id':'Demo','name':'Demo','popupInfo':'#AllAttributes'},'type':'Tile','source':{'type':'TileWMS','properties':{'crossOrigin':'anonymous','params':{'LAYERS':'Demo','TILED':'TRUE'},'url':'http://proxy.com/?url=http://demo.geonode.org/geoserver/wms'}}}],'view':{'center':[0,0],'projection':'EPSG:102113','zoom':3}};
       assert.equal(JSON.stringify(result), JSON.stringify(expected));
     });
   });

--- a/__tests__/services/MapConfigTransformService.test.js
+++ b/__tests__/services/MapConfigTransformService.test.js
@@ -80,5 +80,13 @@ describe('MapConfigTransfrormService', function() {
     var expected = {'layers':[{'properties':{'isRemovable':true,'visible':true,'title':'Roman and Medieval Civilization','id':'  Roman and Medieval Civilization','name':'  Roman and Medieval Civilization'},'type':'Tile','source':{'type':'TileArcGISRest','properties':{'crossOrigin':'anonymous','urls':['http://cga6.cga.harvard.edu/arcgis/rest/services/darmc/roman/MapServer'],'params':{'LAYERS':'show:0','FORMAT':'png'}}}}],'view':{'center':[4263719.1382864,5532513.4852863],'projection':'EPSG:102113','zoom':3}};
     assert.equal(JSON.stringify(result), JSON.stringify(expected));
   });
+  describe('has proxy', function() {
+    it('transforms MapBox source correctly', function() {
+      var config = {'sources':{'1':{'ptype':'gxp_wmscsource','projection':'EPSG:102113', 'url': 'http://demo.geonode.org/geoserver/wms'}},'map':{'projection':'EPSG:102113','layers':[{'source':'1','name':'Demo','title':'Demo','visibility':true,'opacity':1,'group':'','fixed':false,'selected':true}],'center':[0,0],'zoom':3}};
+      var result = MapConfigTransformService.transform(config, 'http://proxy.com/?url=');
+      var expected = {'layers':[{'properties':{'isRemovable':true,'visible':true,'title':'Demo','id':'Demo','name':'Demo','popupInfo':'#AllAttributes'},'type':'Tile','source':{'type':'TileWMS','properties':{'crossOrigin':'anonymous','params':{'LAYERS':'Demo','TILED':'TRUE'},'url':'http://proxy.com/?url=http://demo.geonode.org/geoserver/wms'}}}],'view':{'center':[0,0],'projection':'EPSG:102113','zoom':3}};
+      assert.equal(JSON.stringify(result), JSON.stringify(expected));
+    });
+  });
 
 });

--- a/js/services/MapConfigTransformService.js
+++ b/js/services/MapConfigTransformService.js
@@ -14,12 +14,15 @@
  * Transforms GXP style map config to our internal format.
  */
 class MapConfigTransformService {
-  transform(data) {
+  transform(data, opt_proxy) {
     var i, ii, layers = [];
     var groups = {};
     for (i = 0, ii = data.map.layers.length; i < ii; ++i) {
       var layer = data.map.layers[i];
       var source = data.sources[layer.source];
+      if (opt_proxy) {
+        source.url = opt_proxy + source.url;
+      }
       var layerConfig = {
         properties: {
           isRemovable: true,

--- a/js/services/MapConfigTransformService.js
+++ b/js/services/MapConfigTransformService.js
@@ -20,8 +20,9 @@ class MapConfigTransformService {
     for (i = 0, ii = data.map.layers.length; i < ii; ++i) {
       var layer = data.map.layers[i];
       var source = data.sources[layer.source];
+      var url = source.url;
       if (opt_proxy) {
-        source.url = opt_proxy + source.url;
+        url = opt_proxy + source.url;
       }
       var layerConfig = {
         properties: {
@@ -46,7 +47,7 @@ class MapConfigTransformService {
           type: 'TileArcGISRest',
           properties: {
             crossOrigin: 'anonymous',
-            urls: [source.url],
+            urls: [url],
             params: {
               LAYERS: layer.layerid,
               FORMAT: layer.format
@@ -81,7 +82,7 @@ class MapConfigTransformService {
           properties: {
             crossOrigin: 'anonymous',
             params: params,
-            url: source.url
+            url: url
           }
         };
       } else if (source.ptype === 'gxp_mapboxsource') {


### PR DESCRIPTION
## What does this PR do?
Adds the ability to use a proxy for the map config sources.

It can be useful especially for testing to use a proxy instead of the direct source url.
A lot of geonode servers don't support CORS and can't be integrated and displayed without a proxy in between.
This change helps in adding support for a proxy. if no proxy is passed in, nothing changes.
