### PR TITLE
Properly handle requesting images with a proxy now

### DIFF
--- a/__tests__/services/WMSService.test.js
+++ b/__tests__/services/WMSService.test.js
@@ -54,10 +54,6 @@ describe('WMSService', function() {
     assert.equal(source instanceof ol.source.TileWMS, true);
     assert.equal(source.getUrls()[0], url);
     assert.equal(source.getParams().LAYERS, layer.Name);
-    var proxy = 'http://proxy/?url=';
-    lyr = WMSService.createLayer(layer, url, titleObj, ol.proj.get('EPSG:3857'), proxy);
-    source = lyr.getSource();
-    assert.equal(source.getUrls()[0], proxy + encodeURIComponent(url));
   });
 
   it('creates correct GetFeatureInfo url', function() {

--- a/js/services/WMSService.js
+++ b/js/services/WMSService.js
@@ -48,6 +48,21 @@ class WMSService {
       }
     };
     var units = projection.getUnits();
+    var source = new ol.source.TileWMS({
+      url: url,
+      wrapX: layer.Layer ? true : false,
+      params: {
+        LAYERS: layer.Name
+      }
+    });
+    if (opt_proxy) {
+      source.setTileLoadFunction((function() {
+        var tileLoadFn = source.getTileLoadFunction();
+        return function(tile, src) {
+          tileLoadFn(tile, util.getProxiedUrl(src, opt_proxy));
+        };
+      })());
+    }
     return new ol.layer.Tile({
       title: titleObj.title,
       emptyTitle: titleObj.empty,
@@ -63,13 +78,7 @@ class WMSService {
       type: layer.Layer ? 'base' : undefined,
       EX_GeographicBoundingBox: layer.EX_GeographicBoundingBox,
       popupInfo: '#AllAttributes',
-      source: new ol.source.TileWMS({
-        url: util.getProxiedUrl(url, opt_proxy),
-        wrapX: layer.Layer ? true : false,
-        params: {
-          LAYERS: layer.Name
-        }
-      })
+      source: source
     });
   }
   getStylesUrl(url, layer, opt_proxy) {


### PR DESCRIPTION
As @milafrerichs pointed out, currently the urls are not correct as we pass the proxied url to openlayers and openlayers appends the request. Instead we need to intercept the request from openlayers and proxy it only when the url is ready