### PR TITLE
added a file watcher and parallelshell to support watching .js and .css

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "build:babel": "NODE_ENV=release babel ./js --out-dir ./release",
     "start": "babel --watch ./js --out-dir ./release",
+    "watch:all": "parallelshell 'npm run start' 'npm run watch:css'",
+    "watch:css": "onchange 'js/components/*.css' -- npm run build:copy:css",
+    "babel": "babel --watch ./js --out-dir ./release",
     "build:copy-files": "babel-node ./scripts/copy-files.js",
     "build:copy:css": "cp js/components/*.css release/components",
     "build:copy:locale": "npm run createdir:locale && npm run i18n && mkdir release/locale && NODE_ENV=release babel locale/en.js > release/locale/en.js",
@@ -111,6 +114,8 @@
     "mochify": "^2.10.0",
     "mochify-istanbul": "^2.4.1",
     "npm-run-all": "^1.2.11",
+    "onchange": "^3.2.1",
+    "parallelshell": "^2.0.0",
     "phantomjs-polyfill-find": "github:ptim/phantomjs-polyfill-find",
     "phantomjs-polyfill-object-assign": "0.0.2",
     "phantomjs-prebuilt": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   },
   "scripts": {
     "build:babel": "NODE_ENV=release babel ./js --out-dir ./release",
-    "start": "babel --watch ./js --out-dir ./release",
-    "watch:all": "parallelshell 'npm run start' 'npm run watch:css'",
+    "start": "parallelshell 'npm run babel' 'npm run watch:css'",
     "watch:css": "onchange 'js/components/*.css' -- npm run build:copy:css",
     "babel": "babel --watch ./js --out-dir ./release",
     "build:copy-files": "babel-node ./scripts/copy-files.js",


### PR DESCRIPTION
Added Parallelshell to support a double watch. 
Added the ability to watch css and JS and move them to the release/
setup: npm i
run: npm run watch:all
also added npm watch:css just to watch for CSS changes