### PR TITLE
Change all animation code

### DIFF
--- a/__tests__/components/Rotate.test.js
+++ b/__tests__/components/Rotate.test.js
@@ -1,0 +1,68 @@
+/* global afterEach, beforeEach, describe, it */
+
+import TestUtils from 'react-addons-test-utils';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {assert} from 'chai';
+import raf from 'raf';
+import ol from 'openlayers';
+import intl from '../mock-i18n';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import 'phantomjs-polyfill-object-assign';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
+import Rotate from '../../js/components/Rotate';
+
+raf.polyfill();
+
+describe('Zoom', function() {
+  var target, map;
+  var width = 360;
+  var height = 180;
+
+  beforeEach(function(done) {
+    target = document.createElement('div');
+    var style = target.style;
+    style.position = 'absolute';
+    style.left = '-1000px';
+    style.top = '-1000px';
+    style.width = width + 'px';
+    style.height = height + 'px';
+    document.body.appendChild(target);
+    map = new ol.Map({
+      target: target,
+      view: new ol.View({
+        center: [0, 0],
+        zoom: 1,
+        rotation: 0.1
+      })
+    });
+    map.once('postrender', function() {
+      done();
+    });
+  });
+
+  afterEach(function() {
+    map.setTarget(null);
+    document.body.removeChild(target);
+  });
+
+  it('rotates the map back to north', function(done) {
+    var container = document.createElement('div');
+    ReactDOM.render((
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <Rotate intl={intl} map={map} />
+      </MuiThemeProvider>
+    ), container);
+    var buttons = container.querySelectorAll('button');
+    var rotate = buttons[0];
+    assert.equal(map.getView().getRotation(), 0.1);
+    TestUtils.Simulate.touchTap(rotate);
+    window.setTimeout(function() {
+      assert.equal(Math.round(map.getView().getRotation()), 0);
+      ReactDOM.unmountComponentAtNode(container);
+      done();
+    }, 1000);
+  });
+
+});

--- a/__tests__/components/Zoom.test.js
+++ b/__tests__/components/Zoom.test.js
@@ -1,0 +1,69 @@
+/* global afterEach, beforeEach, describe, it */
+
+import TestUtils from 'react-addons-test-utils';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {assert} from 'chai';
+import raf from 'raf';
+import ol from 'openlayers';
+import intl from '../mock-i18n';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import 'phantomjs-polyfill-object-assign';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
+import Zoom from '../../js/components/Zoom';
+
+raf.polyfill();
+
+describe('Zoom', function() {
+  var target, map;
+  var width = 360;
+  var height = 180;
+
+  beforeEach(function(done) {
+    target = document.createElement('div');
+    var style = target.style;
+    style.position = 'absolute';
+    style.left = '-1000px';
+    style.top = '-1000px';
+    style.width = width + 'px';
+    style.height = height + 'px';
+    document.body.appendChild(target);
+    map = new ol.Map({
+      target: target,
+      view: new ol.View({
+        center: [0, 0],
+        zoom: 1
+      })
+    });
+    map.once('postrender', function() {
+      done();
+    });
+  });
+
+  afterEach(function() {
+    map.setTarget(null);
+    document.body.removeChild(target);
+  });
+
+  it('zooms in', function(done) {
+    var container = document.createElement('div');
+    ReactDOM.render((
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <Zoom intl={intl} map={map} />
+      </MuiThemeProvider>
+    ), container);
+    var buttons = container.querySelectorAll('button');
+    var zoomin = buttons[0];
+    assert.equal(map.getView().getZoom(), 1);
+    assert.equal(map.getView().getCenter()[0], 0);
+    assert.equal(map.getView().getCenter()[1], 0);
+    TestUtils.Simulate.touchTap(zoomin);
+    window.setTimeout(function() {
+      assert.equal(Math.round(map.getView().getZoom()), 2);
+      ReactDOM.unmountComponentAtNode(container);
+      done();
+    }, 1000);
+  });
+
+});

--- a/js/components/Rotate.js
+++ b/js/components/Rotate.js
@@ -92,20 +92,14 @@ class Rotate extends React.PureComponent {
     var currentRotation = view.getRotation();
     if (currentRotation !== 0) {
       if (this.props.duration > 0) {
-        currentRotation = currentRotation % (2 * Math.PI);
-        if (currentRotation < -Math.PI) {
-          currentRotation += 2 * Math.PI;
-        }
-        if (currentRotation > Math.PI) {
-          currentRotation -= 2 * Math.PI;
-        }
-        map.beforeRender(ol.animation.rotate({
-          rotation: currentRotation,
+        view.animate({
+          rotation: 0,
           duration: this.props.duration,
           easing: ol.easing.easeOut
-        }));
+        });
+      } else {
+        view.setRotation(0);
       }
-      view.setRotation(0);
     }
   }
   render() {

--- a/js/components/Zoom.js
+++ b/js/components/Zoom.js
@@ -107,15 +107,21 @@ class Zoom extends React.PureComponent {
     var view = map.getView();
     var currentResolution = view.getResolution();
     if (currentResolution) {
+      var newResolution = view.constrainResolution(currentResolution, delta);
       if (this.props.duration > 0) {
-        map.beforeRender(ol.animation.zoom({
-          resolution: currentResolution,
+/* TODO: not yet API see https://github.com/openlayers/openlayers/issues/6548
+        if (view.getAnimating()) {
+          view.cancelAnimations();
+        }
+*/
+        view.animate({
+          resolution: newResolution,
           duration: this.props.duration,
           easing: ol.easing.easeOut
-        }));
+        });
+      } else {
+        view.setResolution(newResolution);
       }
-      var newResolution = view.constrainResolution(currentResolution, delta);
-      view.setResolution(newResolution);
     }
   }
   render() {


### PR DESCRIPTION
There was still some code using the old deprecated animations, and since we did not have any unit tests, I didn't catch this.

Added unit tests and updated the code.

SDK-328