### PR TITLE
Handle WFS layers without featureNS from QGIS WAB

### DIFF
--- a/__tests__/stores/LayerStore.test.js
+++ b/__tests__/stores/LayerStore.test.js
@@ -122,6 +122,23 @@ describe('LayerStore', function() {
       error = true;
     }
     assert.equal(error, false);
+    // QGIS WAB no featureNS handled
+    var wab = new ol.layer.Vector({
+      title: 'topp:states',
+      id: 'topp_states20170316114032352',
+      wfsInfo: {
+        featureNS: '',
+        featureType: 'states',
+        featurePrefix: 'topp',
+        geometryType: 'MultiPolygon',
+        geometryName: 'the_geom',
+        url: 'http://localhost:8080/geoserver/wfs'
+      },
+      isWFST: true
+    });
+    map.addLayer(wab);
+    assert.equal(wab.get('name'), 'topp:states');
+    assert.equal(wab.get('url'), 'http://localhost:8080/geoserver/wfs');
   });
 
 });

--- a/src/stores/LayerStore.js
+++ b/src/stores/LayerStore.js
@@ -55,7 +55,12 @@ class LayerStore extends EventEmitter {
     if (!(layer instanceof ol.layer.Group)) {
       var source = layer.getSource();
       if ((source instanceof ol.source.ImageWMS || source instanceof ol.source.TileWMS) || layer.get('isWFST')) {
-        if (!layer.get('wfsInfo')) {
+        if (!layer.get('wfsInfo') || (layer.get('wfsInfo') && !layer.get('wfsInfo').featureNS)) {
+          // QGIS WAB does not know featureNS, but has the rest of the info
+          if (layer.get('wfsInfo') && !layer.get('wfsInfo').featureNS) {
+            layer.set('url', layer.get('wfsInfo').url);
+            layer.set('name', layer.get('wfsInfo').featurePrefix + ':' + layer.get('wfsInfo').featureType);
+          }
           this._getWfsInfo(layer);
         }
         if (!layer.get('styleName')) {


### PR DESCRIPTION
this came up in my testing of https://github.com/boundlessgeo/qgis-webappbuilder-plugin/issues/224

It seems not possible for QGIS to get the featureNS see: https://github.com/boundlessgeo/qgis-webappbuilder-plugin/issues/245#issuecomment-286786623