### PR TITLE
First implementation of full-screen component

### DIFF
--- a/__tests__/components/Fullscreen.test.js
+++ b/__tests__/components/Fullscreen.test.js
@@ -1,0 +1,66 @@
+/* global afterEach, beforeEach, describe, it */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {assert} from 'chai';
+import raf from 'raf';
+import ol from 'openlayers';
+import intl from '../mock-i18n';
+import TestUtils from 'react-addons-test-utils';
+import 'phantomjs-polyfill-object-assign';
+import Fullscreen from '../../src/components/Fullscreen';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+
+raf.polyfill();
+
+describe('Fullscreen', function() {
+  var target, map;
+  var width = 360;
+  var height = 180;
+
+  beforeEach(function(done) {
+    target = document.createElement('div');
+    var style = target.style;
+    style.position = 'absolute';
+    style.left = '-1000px';
+    style.top = '-1000px';
+    style.width = width + 'px';
+    style.height = height + 'px';
+    document.body.appendChild(target);
+    map = new ol.Map({
+      target: target,
+      view: new ol.View({
+        center: [0, 0],
+        zoom: 1
+      })
+    });
+    map.once('postrender', function() {
+      done();
+    });
+  });
+
+  afterEach(function() {
+    map.setTarget(null);
+    document.body.removeChild(target);
+  });
+
+
+  it('goes fullscreen when home button is pressed', function() {
+    var container = document.createElement('div');
+    ReactDOM.render((
+      <MuiThemeProvider muiTheme={getMuiTheme()}>
+        <Fullscreen intl={intl} map={map}/>
+      </MuiThemeProvider>
+    ), container);
+    var button = container.querySelector('button');
+    var called = false;
+    map.getTargetElement().webkitRequestFullscreen = function() {
+      called = true;
+    };
+    TestUtils.Simulate.touchTap(button);
+    assert.equal(called, true);
+    ReactDOM.unmountComponentAtNode(container);
+  });
+
+});

--- a/src/components/Fullscreen.js
+++ b/src/components/Fullscreen.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015-present Boundless Spatial Inc., http://boundlessgeo.com
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import React from 'react';
+import ol from 'openlayers';
+import {defineMessages, injectIntl, intlShape} from 'react-intl';
+import classNames from 'classnames';
+import Button from './Button';
+import FullScreenIcon from 'material-ui/svg-icons/navigation/fullscreen';
+
+const messages = defineMessages({
+  buttontitle: {
+    id: 'fullscreen.buttontitle',
+    description: 'Title for the fullscreen button',
+    defaultMessage: 'Full-screen map'
+  }
+});
+
+/**
+ * A button to enable full-screen mode on the map.
+ *
+ * ```xml
+ * <Fullscreen map={map} />
+ * ```
+ */
+class Fullscreen extends React.PureComponent {
+  static propTypes = {
+    /**
+     * The ol3 map to use.
+     */
+    map: React.PropTypes.instanceOf(ol.Map).isRequired,
+    /**
+     * Position of the tooltip.
+     */
+    tooltipPosition: React.PropTypes.oneOf(['bottom', 'bottom-right', 'bottom-left', 'right', 'left', 'top-right', 'top', 'top-left']),
+    /**
+     * Css class name to apply on the root element of this component.
+     */
+    className: React.PropTypes.string,
+    /**
+     * @ignore
+     */
+    intl: intlShape.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+  }
+  isFullScreenSupported() {
+    var body = document.body;
+    return !!(
+      body.webkitRequestFullscreen ||
+      (body.mozRequestFullScreen && document.mozFullScreenEnabled) ||
+      (body.msRequestFullscreen && document.msFullscreenEnabled) ||
+      (body.requestFullscreen && document.fullscreenEnabled)
+    );
+  }
+  isFullScreen() {
+    return !!(
+      document.webkitIsFullScreen || document.mozFullScreen ||
+      document.msFullscreenElement || document.fullscreenElement
+    );
+  }
+  requestFullScreen(element) {
+    if (element.requestFullscreen) {
+      element.requestFullscreen();
+    } else if (element.msRequestFullscreen) {
+      element.msRequestFullscreen();
+    } else if (element.mozRequestFullScreen) {
+      element.mozRequestFullScreen();
+    } else if (element.webkitRequestFullscreen) {
+      element.webkitRequestFullscreen();
+    }
+  }
+  exitFullScreen() {
+    if (document.exitFullscreen) {
+      document.exitFullscreen();
+    } else if (document.msExitFullscreen) {
+      document.msExitFullscreen();
+    } else if (document.mozCancelFullScreen) {
+      document.mozCancelFullScreen();
+    } else if (document.webkitExitFullscreen) {
+      document.webkitExitFullscreen();
+    }
+  }
+  _handleFullScreen() {
+    if (!this.isFullScreenSupported()) {
+      return;
+    }
+    var map = this.props.map;
+    if (!map) {
+      return;
+    }
+    if (this.isFullScreen()) {
+      this.exitFullScreen();
+    } else {
+      var element = map.getTargetElement();
+      this.requestFullScreen(element);
+    }
+  }
+  _goFullscreen() {
+    this._handleFullScreen();
+  }
+  render() {
+    const {formatMessage} = this.props.intl;
+    return (
+      <Button tooltipPosition={this.props.tooltipPosition} buttonType='Action' mini={true} secondary={true} className={classNames('sdk-component full-screen', this.props.className)} tooltip={formatMessage(messages.buttontitle)} onTouchTap={this._goFullscreen.bind(this)} ><FullScreenIcon /></Button>
+    );
+  }
+}
+
+export default injectIntl(Fullscreen);

--- a/src/full.js
+++ b/src/full.js
@@ -63,6 +63,9 @@ global.EditPopup = EditPopup;
 import FeatureTable from './components/FeatureTable';
 global.FeatureTable = FeatureTable;
 
+import Fullscreen from './components/Fullscreen';
+global.Fullscreen = Fullscreen;
+
 import Geocoding from './components/Geocoding';
 global.Geocoding = Geocoding;
 


### PR DESCRIPTION
SDK-360

the zoom buttons etc. are not visible in the fullscreen mode, since they are not in the map's viewport, not sure if this is an issue though. You can use keyboard and mouse for map navigation in fullscreen mode.

Also, I did not implement an exit button, since the browser already notifies that Esc exits fullscreen mode.