### PR TITLE
Fix conflicting react versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "author": "Boundless Spatial, Inc.",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "react": "15.3.2",
-    "react-dom": "15.3.2",
-    "react-tap-event-plugin": "^1.0.0"
+    "react": "15.4.2",
+    "react-dom": "15.4.2",
+    "react-tap-event-plugin": "^2.0.0"
   },
   "dependencies": {
     "blueimp-canvas-to-blob": "2.2.2",
@@ -129,11 +129,11 @@
     "phantomjs-polyfill-object-assign": "0.0.2",
     "phantomjs-prebuilt": "^2.1.7",
     "raf": "^3.2.0",
-    "react": "15.3.2",
-    "react-addons-test-utils": "15.3.2",
+    "react": "15.4.2",
+    "react-addons-test-utils": "15.4.2",
     "react-docgen": "^2.2.0",
-    "react-dom": "15.3.2",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-dom": "15.4.2",
+    "react-tap-event-plugin": "^2.0.0",
     "rimraf": "^2.5.3",
     "sinon": "^1.12.2",
     "through": "^2.3.8",


### PR DESCRIPTION
Material UI was including React at 15.4.2, but the
application's React version was set to 15.3.2.  This was
causing all of the tests to fail due to multiple included
versions of React.

This change puts all of the versions into harmony.  At least,
they are harmonious enough for all of the tests to pass in master.