### PR TITLE
Change Login and MapConfig to use icons

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -12,8 +12,6 @@
 
 import React from 'react';
 import classNames from 'classnames';
-import IconMenu from 'material-ui/IconMenu';
-import MenuItem from 'material-ui/MenuItem';
 import Button from './Button';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import LoginModal from './LoginModal';
@@ -139,13 +137,11 @@ class Login extends React.PureComponent {
     const {formatMessage} = this.props.intl;
     if (this.state.user !== null) {
       return (
-        <IconMenu anchorOrigin={{horizontal: 'left', vertical: 'top'}} targetOrigin={{horizontal: 'left', vertical: 'top'}} className={classNames('sdk-component login', this.props.className)} iconButtonElement={<Button label={this.state.user} />} onItemTouchTap={this._doLogout.bind(this)}>
-          <MenuItem primaryText={formatMessage(messages.logouttext)}/>
-        </IconMenu>
+        <Button buttonType='Icon' iconClassName='headerIcons fa fa-sign-out' className={classNames('sdk-component login', this.props.className)} onItemTouchTap={this._doLogout.bind(this)} tooltip={formatMessage(messages.logouttext)}/>
       );
     } else {
       return (
-        <Button className={classNames('sdk-component login', this.props.className)} label={formatMessage(messages.buttontext)} onTouchTap={this._showLoginDialog.bind(this)}>
+        <Button buttonType='Icon' iconClassName='headerIcons fa fa-sign-in' className={classNames('sdk-component login', this.props.className)} tooltip={formatMessage(messages.buttontext)} onTouchTap={this._showLoginDialog.bind(this)}>
           <LoginModal close={this._onClose.bind(this)} open={this.state.modalOpen} {...this.props} />
         </Button>
       );

--- a/src/components/MapConfig.js
+++ b/src/components/MapConfig.js
@@ -16,10 +16,9 @@ import classNames from 'classnames';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
 import Snackbar from 'material-ui/Snackbar';
-import IconButton from 'material-ui/IconButton';
+import Button from './Button';
 import MapConfigService from '../services/MapConfigService';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
-import NavigationMoreVert from 'material-ui/svg-icons/navigation/more-vert';
 
 const messages = defineMessages({
   savetext: {
@@ -178,7 +177,7 @@ class MapConfig extends React.PureComponent {
         style={this.props.style}
         className={classNames('sdk-component map-config headerIcons', this.props.className)}
         anchorOrigin={{horizontal: 'right', vertical: 'bottom'}} targetOrigin={{horizontal: 'right', vertical: 'top'}}
-        iconButtonElement={<IconButton  disabled={this.state.disabled}><NavigationMoreVert/></IconButton>}
+        iconButtonElement={<Button tooltip={formatMessage(messages.dropdowntext)} buttonType='Icon' disabled={this.state.disabled} iconClassName='headerIcons ms ms-map-o'/>}
         value={this.state.value}
         onChange={this._handleChange.bind(this)}>
         <MenuItem disabled={this.state.disabled} value={1} primaryText={formatMessage(messages.loadtext)}  />


### PR DESCRIPTION
So the flexible ellipsis option described in SDK-419 had all kinds of issues (interactions deactivated too early, modals dismissed too early), so I decided to go with an alternative path, i.e. change Login to use IconButtons and change MapConfig to use a different icon other than the ellipsis icon that suggests that we can put other things in there. We can revisit an ellipsis option later after 1.0 release, but this seems the only viable option for now.