### PR TITLE
Bring back toggle mode for layer list

### DIFF
--- a/src/components/LayerList.js
+++ b/src/components/LayerList.js
@@ -235,6 +235,7 @@ class LayerList extends React.PureComponent {
     super(props);
     LayerStore.bindMap(this.props.map);
     this.state = {
+      visible: props.showOnStart,
       addLayerOpen: false,
       muiTheme: context.muiTheme || getMuiTheme(),
       baseLayer: ''
@@ -245,9 +246,6 @@ class LayerList extends React.PureComponent {
     this._onChangeCb = this._onChange.bind(this);
     LayerStore.addChangeListener(this._onChangeCb);
     this._onChange();
-    if (this.props.showOnStart) {
-      this._showPanel();
-    }
   }
   componentWillUnmount() {
     LayerStore.removeChangeListener(this._onChangeCb);
@@ -299,11 +297,6 @@ class LayerList extends React.PureComponent {
       addLayerOpen: false
     });
   }
-  _showPanel(evt) {
-    if (!this.state.visible) {
-      this.setState({visible: true});
-    }
-  }
   _togglePanel() {
     var newVisible = !this.state.visible;
     if (newVisible || this._modalOpen !== true) {
@@ -344,7 +337,6 @@ class LayerList extends React.PureComponent {
     var layers = this.state.layers.slice(0).reverse();
     var divClass = {
       'layer-switcher': true,
-      'shown': this.state.visible,
       'sdk-component': true,
       'layer-list': true
     };
@@ -370,7 +362,7 @@ class LayerList extends React.PureComponent {
     return (
       <div ref='parent' className={classNames(divClass, this.props.className)}>
         <Button tooltipPosition={this.props.tooltipPosition} buttonType='Action' mini={true} className='layerlistbutton' tooltip={formatMessage(messages.layertitle)} onTouchTap={this._togglePanel.bind(this)}><LayersIcon /></Button>
-        <Paper zDepth={0} className='layer-tree-panel'>
+        <Paper style={{display : this.state.visible ? 'block' : 'none'}} zDepth={0} className='layer-tree-panel'>
           {tipLabel}
           <List className='layer-list-list'>
             {this.renderLayers(layers)}

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -24,7 +24,6 @@ import MenuItem from 'material-ui/MenuItem';
 import {defineMessages, injectIntl, intlShape} from 'react-intl';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import Button from './Button';
-import IconButton from 'material-ui/IconButton';
 import Divider from 'material-ui/Divider';
 import Delete from 'material-ui/svg-icons/action/delete';
 


### PR DESCRIPTION
This brings back toggle mode for layer list with a bit of css at the app level as can be seen here: https://github.com/boundlessgeo/sdk-apps/commit/ac9e312290b7afce9cd30a07ddc330d56235c8c2

@volaya we probably need to make a similar change as the one above in WAB

![selection_232](https://cloud.githubusercontent.com/assets/319678/25242388/acd38c22-25f9-11e7-97ab-2ccbd86ad41c.png)
![selection_231](https://cloud.githubusercontent.com/assets/319678/25242387/acd32106-25f9-11e7-8f3c-b7dcb113a507.png)
