### PR TITLE
Protect against tablemodal ref not being initialised

### DIFF
--- a/src/components/LayerListItem.js
+++ b/src/components/LayerListItem.js
@@ -590,7 +590,9 @@ static formats = {
     this.props.layer.setOpacity(value);
   }
   _onTableUpdate() {
-    this.refs.tablemodal.forceUpdate();
+    if (this.refs.tablemodal) {
+      this.refs.tablemodal.forceUpdate();
+    }
   }
   calculateInRange() {
     if (!this.props.handleResolutionChange) {


### PR DESCRIPTION
This is happening in some cases with the code generated by WAB