### PR TITLE
Do not allow edit tools in table modal

### DIFF
--- a/src/components/LayerListItem.js
+++ b/src/components/LayerListItem.js
@@ -698,7 +698,9 @@ static formats = {
       ];
       tableModal = (
         <Dialog ref='tablemodal' inline={this.props.inlineDialogs} actions={actions} title={formatMessage(messages.tablemodaltitle)} open={this.state.tableOpen} onRequestClose={this._closeTable.bind(this)}>
-          <FeatureTable height={400} onUpdate={this._onTableUpdate.bind(this)} map={this.props.map} layer={this.props.layer} />
+          <div style={{height: 400}}>
+            <FeatureTable allowEdit={this.props.inlineDialogs} onUpdate={this._onTableUpdate.bind(this)} map={this.props.map} layer={this.props.layer} />
+          </div>
         </Dialog>
       );
     }


### PR DESCRIPTION
this came up in: https://github.com/boundlessgeo/qgis-webappbuilder-plugin/issues/337

for the table modal the edit tools make no sense
![selection_261](https://cloud.githubusercontent.com/assets/319678/26158989/af29b01c-3b1d-11e7-9714-82195f72ae28.png)

