### PR TITLE
only saving relevant zoom info in state tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "react-tap-event-plugin": "^1.0.0"
   },
   "dependencies": {
-    "@boundlessgeo/jsonix": "^2.4.1",
     "axios": "^0.16.1",
     "blueimp-canvas-to-blob": "2.2.2",
     "browser-filesaver": "^1.1.0",

--- a/src/actions/MapActions.js
+++ b/src/actions/MapActions.js
@@ -19,9 +19,9 @@
      mapState: MapConfigService.getMapState(map)
    }
  }
- export const setView = (center, resolution, zoom) => {
+ export const setView = (center, zoom) => {
    return {
      type: MAP.SET_VIEW,
-     center, resolution, zoom
+     center, zoom
    }
  }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -24,9 +24,8 @@ const mapStateToProps = (state) => {
 // Maps actions to props
 const mapDispatchToProps = (dispatch) => {
   return {
-    // getMapLayers: mapLayers => dispatch(mapPanelActions.getMapLayers(mapLayers)),
     getMap: map => dispatch(MapActions.getMap(map)),
-    setView: (center, resolution, zoom) => dispatch(MapActions.setView(center, resolution, zoom))
+    setView: (center, zoom) => dispatch(MapActions.setView(center, zoom))
   }
 };
 

--- a/src/components/MapView.js
+++ b/src/components/MapView.js
@@ -14,16 +14,8 @@
  import ReactDOM from 'react-dom';
  import ol from 'openlayers';
  import './MapPanel.css';
- import {defineMessages, injectIntl, intlShape} from 'react-intl';
+ import {injectIntl, intlShape} from 'react-intl';
  import classNames from 'classnames';
-
- const messages = defineMessages({
-   errormsg: {
-     id: 'layerlist.errormsg',
-     description: 'Error message if loading tiles / images fails',
-     defaultMessage: 'There was an error loading tiles.'
-   }
- });
 
 
  /**
@@ -74,7 +66,7 @@
     this._proxy = context.proxy;
     this._requestHeaders = context.requestHeaders;
     if (this.props.hasOwnProperty('getMap')) {
-      this.props.getMap(this.props.map);
+      //this.props.getMap(this.props.map);
     }
   }
 
@@ -87,8 +79,7 @@
       let view = map.getView();
       // create a "mapAction" and dispatch it.
       // this.props.store.dispatch(mapActions.move(view.getCenter(), view.getResolution()));
-      this.props.setView(view.getCenter(),view.getResolution(),view.getZoom()
-      );
+      this.props.setView(view.getCenter(), view.getZoom());
     });
   }
   componentWillUpdate(nextProps, nextState) {
@@ -106,7 +97,7 @@
   }
   render() {
     return (
-      <div style={this.props.style} id={this.props.id} ref='map' className={classNames('sdk-component map-panel willie', this.props.className)}>
+      <div style={this.props.style} id={this.props.id} ref='map' className={classNames('sdk-component map-panel', this.props.className)}>
         {this.props.children}
       </div>
     );

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -9,8 +9,7 @@ export default (state = [], action) => {
         view:{
           ...state.view,
           center:action.center,
-          zoom:action.zoom,
-          resolution:action.resolution
+          zoom:action.zoom
         }
       };
     case MAP.ZOOM_IN:


### PR DESCRIPTION
simplifying what is stored in state tree until more actions are created. trying to prevent erroneous, out-of-date map data from being stored in state tree