### PR TITLE
Fix layer visibility updates

### DIFF
--- a/__tests__/components/map.test.js
+++ b/__tests__/components/map.test.js
@@ -115,6 +115,46 @@ describe('Map component', () => {
     expect(source).toBeInstanceOf(TileJSONSource);
   });
 
+  it('should handle visibility changes', function() {
+    const sources = {
+      "tilejson": {
+        "type": "raster",
+        "url": "https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure"
+      }
+    };
+    const layers = [{
+      "id": "tilejson-layer",
+      "source": "tilejson"
+    }];
+    const center = [0, 0];
+    const zoom = 2;
+    const _sourcesVersion = 0, _layersVersion = 0;
+    const wrapper = shallow(<Map map={{center, zoom, sources, layers, _sourcesVersion, _layersVersion}} />);
+    const instance = wrapper.instance();
+    instance.componentDidMount();
+    const map = instance.map;
+    const layer = map.getLayers().item(0);
+    expect(layer.getVisible()).toBe(true);
+    const nextProps = {
+      map: {
+        center,
+        zoom,
+        _sourcesVersion: 0,
+        _layersVersion: 1,
+        sources,
+        layers: [{
+          "id": "tilejson-layer",
+          "source": "tilejson",
+          "layout": {
+            visibility: "none"
+          }
+        }]
+      }
+    };
+    instance.shouldComponentUpdate.call(instance, nextProps);
+    expect(layer.getVisible()).toBe(false);
+  });
+
   it('should created a connected map', function() {
     const store = createStore(combineReducers({
       map: MapReducer,

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -190,7 +190,6 @@ export class Map extends React.Component {
     for(let i = 0, ii = layersDef.length; i < ii; i++) {
       const layer = layersDef[i];
       const is_visible = layer.layout ? layer.layout.visibility !== 'none' : true;
-
       layer_exists[layer.id] = true;
 
       if(!(layer.id in this.layers)) {
@@ -225,12 +224,12 @@ export class Map extends React.Component {
             this.map.addLayer(this.layers[layer.id]);
           }
         }
+      }
 
-        // handle visibility and z-ordering.
-        if(layer.id in this.layers) {
-          this.layers[layer.id].setVisible(is_visible);
-          this.layers[layer.id].setZIndex(i);
-        }
+      // handle visibility and z-ordering.
+      if(layer.id in this.layers) {
+        this.layers[layer.id].setVisible(is_visible);
+        this.layers[layer.id].setZIndex(i);
       }
     }
 


### PR DESCRIPTION
Currently, hide OSM is broken in the basic example.
This fixes it, and creates a unit test for it.