### PR TITLE
gl layer maxZoom converting to ol layer maxRes

### DIFF
--- a/__tests__/components/map.test.jsx
+++ b/__tests__/components/map.test.jsx
@@ -210,6 +210,52 @@ describe('Map component', () => {
     expect(layer.getVisible()).toBe(false);
   });
 
+  it('handles updated layers', () => {
+    const sources = {
+      tilejson: {
+        type: 'raster',
+        url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
+      },
+    };
+    const layers = [{
+      id: 'tilejson-layer',
+      source: 'tilejson',
+      minZoom: 2,
+    }];
+
+    const metadata = {
+      'bnd:source-version': 0,
+      'bnd:layer-version': 0,
+    };
+    const center = [0, 0];
+    const zoom = 2;
+    const wrapper = shallow(<Map map={{ center, zoom, sources, layers, metadata }} />);
+
+    const instance = wrapper.instance();
+    instance.componentDidMount();
+    const map = instance.map;
+    const layer = map.getLayers().item(0);
+    expect(layer.getMaxResolution()).toEqual(39136);
+    const nextProps = {
+      map: {
+        center,
+        zoom,
+        metadata: {
+          'bnd:source-version': 0,
+          'bnd:layer-version': 1,
+        },
+        sources,
+        layers: [{
+          id: 'tilejson-layer',
+          source: 'tilejson',
+          minZoom: 3,
+        }],
+      },
+    };
+    instance.shouldComponentUpdate.call(instance, nextProps);
+    expect(layer.getMaxResolution()).toEqual(19568);
+  });
+
   it('should handle layer removal and re-adding', () => {
     const sources = {
       tilejson: {

--- a/__tests__/reducers/map.test.js
+++ b/__tests__/reducers/map.test.js
@@ -216,7 +216,7 @@ describe('map reducer', () => {
     });
   });
 
-  it('should handle UPDATE_LAYER', () => {
+  it('should handle UPDATE_LAYER (background type)', () => {
     const layer = {
       id: 'background',
       type: 'background',
@@ -267,6 +267,62 @@ describe('map reducer', () => {
         'bnd:layer-version': 1,
       },
       layers: [newLayer, other_layer],
+    });
+  });
+
+  it('should handle UPDATE_LAYER (circle type)', () => {
+    const layer = {
+      id: 'random-points',
+      source: 'points',
+      type: 'circle',
+      paint: {
+        'circle-radius': 5,
+        'circle-color': '#756bb1',
+        'circle-stroke-color': '#756bb1',
+      },
+    };
+    const newLayer = {
+      id: 'random-points',
+      source: 'points',
+      type: 'circle',
+      paint: {
+        'circle-radius': 10,
+        'circle-color': '#756bb1',
+        'circle-stroke-color': '#756bb1',
+      },
+    };
+    deepFreeze(layer);
+    deepFreeze(newLayer);
+    const action = {
+      type: MAP.UPDATE_LAYER,
+      layerId: 'random-points',
+      layerDef: newLayer,
+    };
+    const state = {
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      sources: {},
+      metadata: {
+        'bnd:source-version': 0,
+        'bnd:layer-version': 0,
+      },
+      layers: [layer],
+    };
+    deepFreeze(state);
+    deepFreeze(action);
+    expect(reducer(state, action)).toEqual({
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      sources: {},
+      metadata: {
+        'bnd:source-version': 0,
+        'bnd:layer-version': 1,
+      },
+      layers: [newLayer],
     });
   });
 

--- a/examples/basic/app.jsx
+++ b/examples/basic/app.jsx
@@ -245,6 +245,18 @@ function main() {
       );
     }
   }
+  // Updates max zoom level on Null Island layer.
+  const updateMaxZoom = () => {
+    store.dispatch(mapActions.updateLayer('null-island', {
+      source: 'points',
+      type: 'circle',
+      paint: {
+        'circle-radius': 10,
+        'circle-color': '#f03b20',
+        'circle-stroke-color': '#f03b20',
+      },
+    }));
+  };
 
   // place the map on the page.
   ReactDOM.render(<SdkMap store={store} />, document.getElementById('map'));
@@ -256,6 +268,7 @@ function main() {
       <button className="sdk-btn" onClick={addRandomPoints}>Add 10 random points</button>
       <button className="sdk-btn blue" onClick={removeRandomPoints}>Remove random points</button>
       <InputField />
+      <button className="sdk-btn" onClick={updateMaxZoom}>Update Max Zoom</button>
     </div>
   ), document.getElementById('controls'));
 }

--- a/src/components/map.jsx
+++ b/src/components/map.jsx
@@ -28,9 +28,7 @@ import VectorSource from 'ol/source/vector';
 
 import GeoJsonFormat from 'ol/format/geojson';
 
-// import { setView } from '../actions/map';
-// import { updateLayer } from '../actions/map';
-import * as mapActions from '../actions/map';
+import { setView } from '../actions/map';
 import { LAYER_VERSION_KEY, SOURCE_VERSION_KEY } from '../constants';
 import { dataVersionKey } from '../reducers/map';
 
@@ -479,7 +477,7 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     setView: (view) => {
-      dispatch(mapActions.setView(view.getCenter(), view.getZoom()));
+      dispatch(setView(view.getCenter(), view.getZoom()));
     },
   };
 }


### PR DESCRIPTION
Helper function in map component converts gl maxZoom val to maxRes val for ol layers 
- only in web mercator projection.

Changes to the basic example app don't perform as expected to re-render the updated layer. A breaking test is included in this PR for a demo but I'll start a new branch for that issue.
