### PR TITLE
Features can now be drawn on the map!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+dist: trusty
+sudo: required 
 
 language: node_js
 
@@ -14,6 +15,8 @@ env:
   - COMMIT_AUTHOR_EMAIL: "bartvde@boundlessgeo.com"
 
 before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g++
   - "npm prune"
 
 before_script:

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,15 @@
+# Boundless SDK
+
+## Testing and the canvas module
+
+The test suite uses the NPM `canvas` module to test certain interactions
+with OpenLayers.  This requires `node-gyp` and the following dependencies:
+
+**Debian/Ubuntu**
+
+```bash
+sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g++
+```
+
+It is possible to run the tests without the `canvas` module. In this case a number
+of tests will be skipped.

--- a/__tests__/actions/drawing.test.js
+++ b/__tests__/actions/drawing.test.js
@@ -1,0 +1,29 @@
+/* global describe, it, expect */
+
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import * as actions from '../../src/actions/drawing';
+import { DRAWING } from '../../src/action-types';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('drawing actions', () => {
+  it('should create an action to start drawing', () => {
+    const geo_type = 'Point';
+    const source = 'test-points';
+
+    const expectedAction = {
+      type: DRAWING.START,
+      interaction: geo_type,
+      sourceName: source,
+    };
+    expect(actions.startDrawing(source, geo_type)).toEqual(expectedAction);
+  });
+
+  it('should create an action to end drawing', () => {
+    expect(actions.endDrawing()).toEqual({type: DRAWING.END});
+  });
+
+});

--- a/__tests__/actions/drawing.test.js
+++ b/__tests__/actions/drawing.test.js
@@ -1,13 +1,7 @@
 /* global describe, it, expect */
 
-import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import * as actions from '../../src/actions/drawing';
 import { DRAWING } from '../../src/action-types';
-
-const middlewares = [thunk];
-const mockStore = configureMockStore(middlewares);
 
 describe('drawing actions', () => {
   it('should create an action to start drawing', () => {
@@ -23,7 +17,6 @@ describe('drawing actions', () => {
   });
 
   it('should create an action to end drawing', () => {
-    expect(actions.endDrawing()).toEqual({type: DRAWING.END});
+    expect(actions.endDrawing()).toEqual({ type: DRAWING.END });
   });
-
 });

--- a/__tests__/components/map-drawing.test.jsx
+++ b/__tests__/components/map-drawing.test.jsx
@@ -1,4 +1,4 @@
-/* global it, describe, expect, beforeEach */
+/* global it, describe, expect, beforeEach, spyOn */
 
 /** Specific tests for map interactions.
  *
@@ -13,10 +13,16 @@ import { mount } from 'enzyme';
 
 import { createStore, combineReducers } from 'redux';
 
+import Feature from 'ol/feature';
+import Point from 'ol/geom/point';
+
 import SdkMap from '../../src/components/map';
 import MapReducer from '../../src/reducers/map';
 import DrawingReducer from '../../src/reducers/drawing';
 
+import * as MapActions from '../../src/actions/map';
+
+import { INTERACTIONS } from '../../src/constants';
 import { DRAWING } from '../../src/action-types';
 
 
@@ -57,37 +63,73 @@ describe('Map with drawing reducer', () => {
 if (HAS_CANVAS) {
   describe('Map component with drawing', () => {
     let store = null;
+    let wrapper = null;
 
     beforeEach(() => {
       store = createStore(combineReducers({
         map: MapReducer,
         drawing: DrawingReducer,
       }));
+
+      store.dispatch(MapActions.addSource('test', {
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates: [0, 0],
+            },
+            properties: { },
+          }],
+        },
+      }));
+
+      store.dispatch(MapActions.addLayer({
+        id: 'points',
+        source: 'test',
+        type: 'circle',
+        paint: {
+          'circle-radius': 5,
+        },
+      }));
+
+      wrapper = mount(<SdkMap store={store} />);
     });
 
     it('turns on a drawing tool', () => {
-      const wrapper = mount(<SdkMap store={store} />);
       const sdk_map = wrapper.instance().getWrappedInstance();
       const ol_map = sdk_map.map;
-
       const n_interactions = ol_map.getInteractions().getLength();
 
       store.dispatch({
         type: DRAWING.START,
-        interaction: 'Point',
+        interaction: INTERACTIONS.point,
         sourceName: 'test',
       });
 
       // if the drawing control has been added to the map then
       //  there should be 1 additional interaction.
       expect(ol_map.getInteractions().getLength()).toBe(n_interactions + 1);
+
+      // get the last interaction, which should be the drawing interaction
+      const draw = ol_map.getInteractions().item(n_interactions);
+
+      const dummy_feature = new Feature();
+      dummy_feature.setGeometry(new Point(5, 5));
+      draw.dispatchEvent({
+        type: 'drawend',
+        feature: dummy_feature,
+      });
+
+      store.dispatch(MapActions.setView([-45, -45], 11));
     });
 
     it('turns off a drawing tool', () => {
-      const wrapper = mount(<SdkMap store={store} />);
       store.dispatch({
         type: DRAWING.START,
-        interaction: 'Point',
+        interaction: INTERACTIONS.point,
         sourceName: 'test',
       });
 
@@ -103,6 +145,79 @@ if (HAS_CANVAS) {
       //  was already started.  Therefore, when the interaction ends then
       //  there should be one less interaction than at the time of observation.
       expect(ol_map.getInteractions().getLength()).toBe(n_interactions - 1);
+    });
+
+    it('turns on feature modification', () => {
+      const sdk_map = wrapper.instance().getWrappedInstance();
+      const ol_map = sdk_map.map;
+
+      const interactions = ol_map.getInteractions();
+      const n_interactions = interactions.getLength();
+
+      store.dispatch({
+        type: DRAWING.START,
+        interaction: INTERACTIONS.modify,
+        sourceName: 'test',
+      });
+
+      // modify differes from select and drawing tools
+      //  as it requires adding two interactions to the map.
+      expect(interactions.getLength()).toBe(n_interactions + 2);
+
+      // get the modify interaction
+      const select = interactions.item(interactions.getLength() - 2);
+      const modify = interactions.item(interactions.getLength() - 1);
+
+      // configure a spy, when a feature is modifyed onFeatureEvent
+      //  should be called.
+      spyOn(sdk_map, 'onFeatureEvent');
+
+      // fake modifying a sample feature.
+      const features = sdk_map.layers.points.getSource().getFeatures();
+      select.getFeatures().push(features[0]);
+
+      modify.dispatchEvent({
+        type: 'modifyend',
+        features: select.getFeatures(),
+      });
+
+      // ensure onFeatureEvent was called.
+      expect(sdk_map.onFeatureEvent).toHaveBeenCalled();
+    });
+
+    it('turns on select', () => {
+      const sdk_map = wrapper.instance().getWrappedInstance();
+      const ol_map = sdk_map.map;
+
+      const n_interactions = ol_map.getInteractions().getLength();
+
+      // kick-off the select interaction.
+      store.dispatch({
+        type: DRAWING.START,
+        interaction: INTERACTIONS.select,
+        sourceName: 'test',
+      });
+
+      // ensure the interaction has been added to the map.
+      const interactions = ol_map.getInteractions();
+      expect(interactions.getLength()).toBe(n_interactions + 1);
+
+      // get the select interaction
+      const select = interactions.item(interactions.getLength() - 1);
+
+      // configure a spy, when a feature is selected onFeatureEvent
+      //  should be called.
+      spyOn(sdk_map, 'onFeatureEvent');
+
+      // fake selecting a sample feature.
+      const features = sdk_map.layers.points.getSource().getFeatures();
+      select.getFeatures().push(features[0]);
+      select.dispatchEvent({
+        type: 'select',
+      });
+
+      // ensure onFeatureEvent was called.
+      expect(sdk_map.onFeatureEvent).toHaveBeenCalled();
     });
   });
 }

--- a/__tests__/components/map-drawing.test.jsx
+++ b/__tests__/components/map-drawing.test.jsx
@@ -1,4 +1,4 @@
-/* global it, describe, expect */
+/* global it, describe, expect, beforeEach */
 
 /** Specific tests for map interactions.
  *
@@ -9,21 +9,22 @@
  */
 
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { createStore, combineReducers } from 'redux';
+
+import SdkMap from '../../src/components/map';
+import MapReducer from '../../src/reducers/map';
+import DrawingReducer from '../../src/reducers/drawing';
+
+import { DRAWING } from '../../src/action-types';
+
 
 // jsdom / enzyme / jest will include <canvas> support
 // but not the full API, this dummys the CanvasPattern
 // and CanvasGradient objects so that OL testing works.
 global.CanvasPattern = function CanvasPattern() {};
 global.CanvasGradient = function CanvasGradient() {};
-
-import Map from '../../src/components/map';
-import MapReducer from '../../src/reducers/map';
-import DrawingReducer from '../../src/reducers/drawing';
-
-import { DRAWING } from '../../src/action-types';
 
 let HAS_CANVAS = false;
 
@@ -32,9 +33,8 @@ try {
   // statically load modules during conversion,
   // require will throw the appropriate error if the module
   // is not found.
-  const canvas = require('canvas');
-  HAS_CANVAS = true;
-} catch(err) {
+  HAS_CANVAS = (typeof require('canvas') !== 'undefined'); // eslint-disable-line global-require
+} catch (err) {
   console.error('No canvas module available, skipping map-drawing tests.');
 }
 
@@ -44,11 +44,11 @@ try {
 describe('Map with drawing reducer', () => {
   it('creates a map with the drawing reducer', () => {
     const store = createStore(combineReducers({
-        map: MapReducer,
-        drawing: DrawingReducer,
+      map: MapReducer,
+      drawing: DrawingReducer,
     }));
 
-    expect(mount(<Map store={store} />).contains(<div className="map" />)).toBe(true);
+    expect(mount(<SdkMap store={store} />).contains(<div className="map" />)).toBe(true);
   });
 });
 
@@ -66,7 +66,7 @@ if (HAS_CANVAS) {
     });
 
     it('turns on a drawing tool', () => {
-      const wrapper = mount(<Map store={store} />);
+      const wrapper = mount(<SdkMap store={store} />);
       const sdk_map = wrapper.instance().getWrappedInstance();
       const ol_map = sdk_map.map;
 
@@ -84,7 +84,7 @@ if (HAS_CANVAS) {
     });
 
     it('turns off a drawing tool', () => {
-      const wrapper = mount(<Map store={store} />);
+      const wrapper = mount(<SdkMap store={store} />);
       store.dispatch({
         type: DRAWING.START,
         interaction: 'Point',

--- a/__tests__/components/map-drawing.test.jsx
+++ b/__tests__/components/map-drawing.test.jsx
@@ -1,0 +1,108 @@
+/* global it, describe, expect */
+
+/** Specific tests for map interactions.
+ *
+ *  This is *not* intended to be a complete test of the map,
+ *  it only tests the drawing related functionality. See map.test.jsx
+ *  for a more complete test of the map component.
+ *
+ */
+
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import { createStore, combineReducers } from 'redux';
+
+// jsdom / enzyme / jest will include <canvas> support
+// but not the full API, this dummys the CanvasPattern
+// and CanvasGradient objects so that OL testing works.
+global.CanvasPattern = function CanvasPattern() {};
+global.CanvasGradient = function CanvasGradient() {};
+
+import Map from '../../src/components/map';
+import MapReducer from '../../src/reducers/map';
+import DrawingReducer from '../../src/reducers/drawing';
+
+import { DRAWING } from '../../src/action-types';
+
+let HAS_CANVAS = false;
+
+try {
+  // The import syntax cannot be used here as it
+  // statically load modules during conversion,
+  // require will throw the appropriate error if the module
+  // is not found.
+  const canvas = require('canvas');
+  HAS_CANVAS = true;
+} catch(err) {
+  console.error('No canvas module available, skipping map-drawing tests.');
+}
+
+
+// without canvas a basic "does it not error out" test will
+//  run fine.
+describe('Map with drawing reducer', () => {
+  it('creates a map with the drawing reducer', () => {
+    const store = createStore(combineReducers({
+        map: MapReducer,
+        drawing: DrawingReducer,
+    }));
+
+    expect(mount(<Map store={store} />).contains(<div className="map" />)).toBe(true);
+  });
+});
+
+
+// require that the canvas element be installed to run these tests.
+if (HAS_CANVAS) {
+  describe('Map component with drawing', () => {
+    let store = null;
+
+    beforeEach(() => {
+      store = createStore(combineReducers({
+        map: MapReducer,
+        drawing: DrawingReducer,
+      }));
+    });
+
+    it('turns on a drawing tool', () => {
+      const wrapper = mount(<Map store={store} />);
+      const sdk_map = wrapper.instance().getWrappedInstance();
+      const ol_map = sdk_map.map;
+
+      const n_interactions = ol_map.getInteractions().getLength();
+
+      store.dispatch({
+        type: DRAWING.START,
+        interaction: 'Point',
+        sourceName: 'test',
+      });
+
+      // if the drawing control has been added to the map then
+      //  there should be 1 additional interaction.
+      expect(ol_map.getInteractions().getLength()).toBe(n_interactions + 1);
+    });
+
+    it('turns off a drawing tool', () => {
+      const wrapper = mount(<Map store={store} />);
+      store.dispatch({
+        type: DRAWING.START,
+        interaction: 'Point',
+        sourceName: 'test',
+      });
+
+      const sdk_map = wrapper.instance().getWrappedInstance();
+      const ol_map = sdk_map.map;
+      const n_interactions = ol_map.getInteractions().getLength();
+
+      store.dispatch({
+        type: DRAWING.END,
+      });
+
+      // The count of interactions was taken when the drawing interaction
+      //  was already started.  Therefore, when the interaction ends then
+      //  there should be one less interaction than at the time of observation.
+      expect(ol_map.getInteractions().getLength()).toBe(n_interactions - 1);
+    });
+  });
+}

--- a/__tests__/components/map-drawing.test.jsx
+++ b/__tests__/components/map-drawing.test.jsx
@@ -160,7 +160,7 @@ if (HAS_CANVAS) {
         sourceName: 'test',
       });
 
-      // modify differes from select and drawing tools
+      // modify differs from select and drawing tools
       //  as it requires adding two interactions to the map.
       expect(interactions.getLength()).toBe(n_interactions + 2);
 
@@ -168,7 +168,7 @@ if (HAS_CANVAS) {
       const select = interactions.item(interactions.getLength() - 2);
       const modify = interactions.item(interactions.getLength() - 1);
 
-      // configure a spy, when a feature is modifyed onFeatureEvent
+      // configure a spy, when a feature is modified onFeatureEvent
       //  should be called.
       spyOn(sdk_map, 'onFeatureEvent');
 

--- a/__tests__/components/map.test.jsx
+++ b/__tests__/components/map.test.jsx
@@ -366,20 +366,35 @@ describe('Map component', () => {
     const store = createStore(combineReducers({
       map: MapReducer,
     }));
+
     const wrapper = mount(<ConnectedMap store={store} />);
     const sdk_map = wrapper.instance().getWrappedInstance();
 
     store.dispatch(MapActions.setView([-45, -45], 11));
+
+    sdk_map.map.getView().setCenter([45, 45]);
     sdk_map.map.dispatchEvent({
       type: 'moveend',
     });
+
+    expect(store.getState().map.center).toEqual([45, 45]);
   });
 
   it('should trigger the popup-related callbacks', () => {
     const store = createStore(combineReducers({
       map: MapReducer,
     }));
-    const wrapper = mount(<ConnectedMap store={store} />);
+    const onClick = () => { };
+
+    // create a props dictionary which
+    //  can include a spy.
+    const props = {
+      store,
+      onClick,
+    };
+    spyOn(props, 'onClick');
+
+    const wrapper = mount(<ConnectedMap {...props} />);
     const sdk_map = wrapper.instance().getWrappedInstance();
     sdk_map.map.dispatchEvent({
       type: 'postcompose',
@@ -394,6 +409,9 @@ describe('Map component', () => {
         target: sdk_map.map.getRenderer().canvas_,
       },
     });
+
+    // onclick should get called when the map is clicked.
+    expect(props.onClick).toHaveBeenCalled();
   });
 
   it('should change the sprites and redraw the layer', () => {

--- a/__tests__/components/map.test.jsx
+++ b/__tests__/components/map.test.jsx
@@ -362,6 +362,40 @@ describe('Map component', () => {
     mount(<ConnectedMap store={store} />);
   });
 
+  it('should trigger the setView callback', () => {
+    const store = createStore(combineReducers({
+      map: MapReducer,
+    }));
+    const wrapper = mount(<ConnectedMap store={store} />);
+    const sdk_map = wrapper.instance().getWrappedInstance();
+
+    store.dispatch(MapActions.setView([-45, -45], 11));
+    sdk_map.map.dispatchEvent({
+      type: 'moveend',
+    });
+  });
+
+  it('should trigger the popup-related callbacks', () => {
+    const store = createStore(combineReducers({
+      map: MapReducer,
+    }));
+    const wrapper = mount(<ConnectedMap store={store} />);
+    const sdk_map = wrapper.instance().getWrappedInstance();
+    sdk_map.map.dispatchEvent({
+      type: 'postcompose',
+    });
+
+    sdk_map.map.dispatchEvent({
+      type: 'singleclick',
+      coordinate: [0, 0],
+      // this fakes the clicking of the canvas.
+      originalEvent: {
+        // eslint-disable-next-line no-underscore-dangle
+        target: sdk_map.map.getRenderer().canvas_,
+      },
+    });
+  });
+
   it('should change the sprites and redraw the layer', () => {
     const store = createStore(combineReducers({
       map: MapReducer,

--- a/__tests__/reducers/drawing.test.js
+++ b/__tests__/reducers/drawing.test.js
@@ -1,0 +1,47 @@
+/* global it, describe, expect */
+
+import deepFreeze from 'deep-freeze';
+
+import reducer from '../../src/reducers/drawing';
+import { DRAWING } from '../../src/action-types';
+
+describe('drawing reducer', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toEqual({
+      interaction: null,
+      sourceName: null,
+    });
+  });
+
+  it('should set the interaction and sourceName', () => {
+    const source_name = 'points-test';
+    const geo_type = 'Point';
+
+    const test_action = {
+      type: DRAWING.START,
+      interaction: geo_type,
+      sourceName: source_name,
+    };
+
+    const expected_state = {
+      interaction: geo_type,
+      sourceName: source_name,
+    };
+
+    expect(reducer(undefined, test_action)).toEqual(expected_state);
+  });
+
+  it('should null out all the things', () => {
+    const initial_state = {
+      interaction: 'Point',
+      sourceName: 'test-points',
+    };
+
+    const expected_state = {
+      interaction: null,
+      sourceName: null,
+    };
+
+    expect(reducer(initial_state, { type: DRAWING.END })).toEqual(expected_state);
+  });
+});

--- a/__tests__/reducers/drawing.test.js
+++ b/__tests__/reducers/drawing.test.js
@@ -36,6 +36,7 @@ describe('drawing reducer', () => {
       interaction: 'Point',
       sourceName: 'test-points',
     };
+    deepFreeze(initial_state);
 
     const expected_state = {
       interaction: null,

--- a/__tests__/reducers/drawing.test.js
+++ b/__tests__/reducers/drawing.test.js
@@ -22,6 +22,7 @@ describe('drawing reducer', () => {
       interaction: geo_type,
       sourceName: source_name,
     };
+    deepFreeze(test_action);
 
     const expected_state = {
       interaction: geo_type,

--- a/examples/drawing/app.css
+++ b/examples/drawing/app.css
@@ -1,0 +1,22 @@
+/*
+ * Basic styling for some form elements.
+ */
+
+input.radius {
+    width: 3em;
+}
+
+span.input {
+    width: 4em;
+    text-align: center;
+}
+
+.control-panel {
+    float: left;
+    margin-right: 15px;
+}
+
+#controls {
+    clear: both;
+    overflow: hidden;
+}

--- a/examples/drawing/app.jsx
+++ b/examples/drawing/app.jsx
@@ -1,7 +1,4 @@
-/** Demo of clustered points in an SDK map.
- *
- *  Contains a Map and demonstrates some of the dynamics of
- *  using the store.
+/** Demo of using the drawing, modify, and select interactions.
  *
  */
 
@@ -103,7 +100,7 @@ function main() {
 
   // Promises are used here as a way to demonstrate that the
   // features could be added asynchronously.  This is useful
-  // in cases in which the feature may need validated by the
+  // in cases in which the feature may need validation by the
   // server before being added to the layer.
   const validateFeature = (sourceName, feature) => {
     const p = new Promise((resolve, reject) => {
@@ -166,7 +163,7 @@ function main() {
     error_div.innerHTML = `Feature ${feature.properties.id} modified.`;
   };
 
-  // Selecting a feature displays it's ID.
+  // Selecting a feature displays its ID.
   const selectFeature = (map, sourceName, feature) => {
     error_div.innerHTML = `Feature with ID ${feature.properties.id} selected.`;
   };

--- a/examples/drawing/app.jsx
+++ b/examples/drawing/app.jsx
@@ -1,0 +1,194 @@
+/** Demo of clustered points in an SDK map.
+ *
+ *  Contains a Map and demonstrates some of the dynamics of
+ *  using the store.
+ *
+ */
+
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import SdkMap from '@boundlessgeo/sdk/components/map';
+import SdkMapReducer from '@boundlessgeo/sdk/reducers/map';
+import SdkDrawingReducer from '@boundlessgeo/sdk/reducers/drawing';
+import * as mapActions from '@boundlessgeo/sdk/actions/map';
+import * as drawingActions from '@boundlessgeo/sdk/actions/drawing';
+
+// This will have webpack include all of the SDK styles.
+import '@boundlessgeo/sdk/stylesheet/sdk.css';
+
+/* eslint-disable no-underscore-dangle */
+const store = createStore(combineReducers({
+  map: SdkMapReducer,
+  drawing: SdkDrawingReducer,
+}), window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+   applyMiddleware(thunkMiddleware));
+
+function main() {
+  // Start with a reasonable global view of hte map.
+  store.dispatch(mapActions.setView([-1759914.3204498321, 3236495.368492126], 2));
+
+  // add the OSM source
+  store.dispatch(mapActions.addSource('osm', {
+    type: 'raster',
+    tileSize: 256,
+    tiles: [
+      'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    ],
+  }));
+
+  // and an OSM layer.
+  // Raster layers need not have any paint styles.
+  store.dispatch(mapActions.addLayer({
+    id: 'osm',
+    source: 'osm',
+  }));
+
+  // Add three individual GeoJSON stores for the
+  // three different geometry types.
+  ['points', 'lines', 'polygons'].forEach((geo_type) => {
+    store.dispatch(mapActions.addSource(geo_type, {
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: [],
+      },
+    }));
+  });
+
+  // setup the points layer
+  store.dispatch(mapActions.addLayer({
+    id: 'points',
+    source: 'points',
+    type: 'circle',
+    paint: {
+      'circle-radius': 5,
+      'circle-color': '#feb24c',
+      'circle-stroke-color': '#f03b20',
+    },
+  }));
+
+  // setup the lines layer
+  store.dispatch(mapActions.addLayer({
+    id: 'linie',
+    source: 'lines',
+    type: 'line',
+    paint: {
+      'line-color': '#f03b20',
+      'line-width': 5,
+    },
+  }));
+
+  // setup the polys layer
+  store.dispatch(mapActions.addLayer({
+    id: 'polys',
+    source: 'polygons',
+    type: 'fill',
+    paint: {
+      'fill-opacity': 0.7,
+      'fill-color': '#feb24c',
+      'fill-outline-color': '#f03b20',
+    },
+  }));
+
+  // Promises are used here as a way to demonstrate that the
+  // features could be added asynchronously.  This is useful
+  // in cases in which the feature may need validated by the
+  // server before being added to the layer.
+  const validateFeature = (sourceName, feature) => {
+    const p = new Promise((resolve, reject) => {
+      const geom_types = {
+        points: 'Point',
+        lines: 'LineString',
+        polygons: 'Polygon',
+      };
+
+      if (feature.geometry.type === geom_types[sourceName]) {
+        resolve(feature);
+      } else {
+        reject('Feature geometry-type does not match source geometry-type.');
+      }
+    });
+
+    return p;
+  };
+
+  let error_div = null;
+
+  // When the feature is drawn on the map, validate it and
+  //  then add it to the source.
+  const addFeature = (map, sourceName, proposedFeature) => {
+    validateFeature(sourceName, proposedFeature)
+      .then((feature) => {
+        store.dispatch(mapActions.addFeatures(sourceName, feature));
+        error_div.innerHTML = 'Featured added.';
+      })
+      .catch((msg) => {
+        if (error_div !== null) {
+          error_div.innerHTML = msg;
+        }
+      });
+  };
+
+  // place the map on the page.
+  ReactDOM.render(<SdkMap onFeatureDrawn={addFeature} store={store} />, document.getElementById('map'));
+
+  let drawing_tool = null;
+  let drawing_layer = 'points';
+
+  // when either the tool or layer changes,
+  //  trigger a change to the drawing.
+  const updateInteraction = () => {
+    if (drawing_tool === 'none') {
+      store.dispatch(drawingActions.endDrawing());
+    } else if (drawing_layer !== null) {
+      store.dispatch(drawingActions.startDrawing(drawing_layer, drawing_tool));
+    }
+  };
+
+  const setLayer = (evt) => {
+    drawing_layer = evt.target.value;
+    updateInteraction();
+  };
+
+  const setDrawingTool = (evt) => {
+    drawing_tool = evt.target.value;
+    updateInteraction();
+  };
+
+  // add some buttons to demo some actions.
+  ReactDOM.render((
+    <div>
+      <div className="control-panel">
+        <h4>Layers</h4>
+        <select onChange={setLayer}>
+          <option value="points">Points</option>
+          <option value="lines">Lines</option>
+          <option value="polygons">Polygons</option>
+        </select>
+      </div>
+      <div className="control-panel">
+        <h4>Drawing tools</h4>
+        <select onChange={setDrawingTool}>
+          <option value="none">None</option>
+          <option value="Point">Draw point</option>
+          <option value="LineString">Draw line</option>
+          <option value="Polygon">Draw polygon</option>
+        </select>
+      </div>
+      <div className="control-panel">
+        <h4>Messages</h4>
+        <div ref={(d) => { error_div = d; }}>
+          Use the select boxes at left to draw on the map.
+        </div>
+      </div>
+    </div>
+  ), document.getElementById('controls'));
+}
+
+main();

--- a/examples/drawing/app.jsx
+++ b/examples/drawing/app.jsx
@@ -113,9 +113,13 @@ function main() {
       };
 
       if (feature.geometry.type === geom_types[sourceName]) {
-        feature.properties = {id: FEATURE_ID};
+        const new_feature = Object.assign({}, feature, {
+          properties: {
+            id: FEATURE_ID,
+          },
+        });
         FEATURE_ID += 1;
-        resolve(feature);
+        resolve(new_feature);
       } else {
         reject('Feature geometry-type does not match source geometry-type.');
       }
@@ -142,9 +146,8 @@ function main() {
   };
 
   const modifyFeature = (map, sourceName, feature) => {
-    console.log('modify feature', sourceName, feature.geometry.coordinates[0].length);
     store.dispatch(mapActions.removeFeatures(sourceName, ['==', 'id', feature.properties.id]));
-    store.dispatch(mapActions.addFeatures(sourceName, [feature,]));
+    store.dispatch(mapActions.addFeatures(sourceName, [feature]));
     error_div.innerHTML = `Feature ${feature.properties.id} modified.`;
   };
 

--- a/examples/drawing/index.html
+++ b/examples/drawing/index.html
@@ -1,0 +1,29 @@
+<html>
+<head>
+    <title>Drawing Example</title>
+    <link rel="stylesheet" type="text/css" href="/dist/sdk.css"/>
+    <link rel="stylesheet" type="text/css" href="../examples.css"/>
+    <link rel="stylesheet" type="text/css" href="./app.css"/>
+</head>
+<body>
+
+    <div id="header">
+        Drawing Example
+    </div>
+
+    <div id="map">
+    </div>
+
+    <div id="controls">
+    </div>
+
+    <div class="info">
+        <h3>Features in this demo</h3>
+        <ul class="info-list">
+            <li>Using drawing controls</li>
+        </ul>
+    </div>
+
+    <script type="text/javascript" src="./drawing.bundle.js"></script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -34,6 +34,10 @@
         <a href="./paint-change/index.html">Paint Change</a><br>
         Demo how change to the paint object of the mapbox style
     </li>
+    <li>
+        <a href="./drawing/index.html">Drawing </a><br>
+        Demonstrates drawing on the map.
+    </li>
 </ul>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
+    "canvas": "^1.6.5",
     "css-loader": "^0.28.4",
     "deep-freeze": "0.0.1",
     "enzyme": "^2.9.1",

--- a/src/action-types.js
+++ b/src/action-types.js
@@ -20,6 +20,12 @@ export const MAP = {
   SET_SPRITES: 'MAP_SET_SPRITES',
 };
 
+export const DRAWING = {
+  START: 'DRAWING_START',
+  END: 'DRAWING_END',
+};
+
 export default {
   MAP,
+  DRAWING,
 };

--- a/src/actions/drawing.js
+++ b/src/actions/drawing.js
@@ -2,7 +2,10 @@
  */
 
 import { DRAWING } from '../action-types';
+import { INTERACTIONS } from '../constants';
 
+/** Action to start an interaction on the map.
+ */
 export function startDrawing(sourceName, drawingType) {
   return {
     type: DRAWING.START,
@@ -11,8 +14,29 @@ export function startDrawing(sourceName, drawingType) {
   };
 }
 
+/** Short-hand action to start modify-feature */
+export function startModify(sourceName) {
+  return startDrawing(sourceName, INTERACTIONS.modify);
+}
+
+/** Short-hand action to start select-feature */
+export function startSelect(sourceName) {
+  return startDrawing(sourceName, INTERACTIONS.select);
+}
+
+/** Stop drawing / select / modify
+ */
 export function endDrawing() {
   return {
     type: DRAWING.END,
   };
+}
+
+// These are just aliases to end drawing.
+export function endModify() {
+  return endDrawing();
+}
+
+export function endSelect() {
+  return endDrawing();
 }

--- a/src/actions/drawing.js
+++ b/src/actions/drawing.js
@@ -1,0 +1,18 @@
+/** Actions for interacting with the map.
+ */
+
+import { DRAWING } from '../action-types';
+
+export function startDrawing(sourceName, drawingType) {
+  return {
+    type: DRAWING.START,
+    interaction: drawingType,
+    sourceName,
+  };
+}
+
+export function endDrawing() {
+  return {
+    type: DRAWING.END,
+  };
+}

--- a/src/components/map.jsx
+++ b/src/components/map.jsx
@@ -54,7 +54,7 @@ const GEOJSON_FORMAT = new GeoJsonFormat();
  *  for undefined values to be returned.
  */
 function getVersion(obj, key) {
-  if (typeof obj.metadata === 'undefined') {
+  if (obj.metadata === undefined) {
     return undefined;
   }
   return obj.metadata[key];
@@ -288,7 +288,7 @@ export class Map extends React.Component {
    *  this.props.onFeatureDrawn.
    */
   onFeatureEvent(eventType, sourceName, feature) {
-    if (typeof feature !== 'undefined') {
+    if (feature !== undefined) {
       // convert the feature to GeoJson
       const proposed_geojson = GEOJSON_FORMAT.writeFeatureObject(feature, {
         dataProjection: 'EPSG:4326',
@@ -449,7 +449,7 @@ export class Map extends React.Component {
       let layer = layersDef[i];
 
       // check to see if this layer references another.
-      if (typeof layer.ref !== 'undefined') {
+      if (layer.ref !== undefined) {
         // find the source layer
         let layer_def = null;
         for (let j = 0, jj = layersDef.length; j < jj && layer_def === null; j++) {
@@ -524,7 +524,7 @@ export class Map extends React.Component {
   }
 
   configureSprites(map) {
-    if (typeof map.sprites === 'undefined') {
+    if (map.sprites === undefined) {
       // return a resolved promise.
       return (new Promise((resolve) => {
         resolve();

--- a/src/components/map.jsx
+++ b/src/components/map.jsx
@@ -17,7 +17,6 @@ import Overlay from 'ol/overlay';
 
 import Proj from 'ol/proj';
 import Coordinate from 'ol/coordinate';
-import Collection from 'ol/collection';
 
 import TileLayer from 'ol/layer/tile';
 import XyzSource from 'ol/source/xyz';
@@ -299,7 +298,7 @@ export class Map extends React.Component {
     //  and the drawn feature.
     if (eventType === 'drawn') {
       this.props.onFeatureDrawn(this, sourceName, proposed_geojson);
-    } else if(eventType === 'modified') {
+    } else if (eventType === 'modified') {
       this.props.onFeatureModified(this, sourceName, proposed_geojson);
     }
   }
@@ -716,7 +715,6 @@ export class Map extends React.Component {
     // this assumes the interaction is different,
     //  so the first thing to do is clear out the old interaction
     if (this.activeInteractions !== null) {
-
       for (let i = 0, ii = this.activeInteractions.length; i < ii; i++) {
         this.map.removeInteraction(this.activeInteractions[i]);
       }
@@ -746,7 +744,7 @@ export class Map extends React.Component {
         this.onFeatureEvent('drawn', drawingProps.sourceName, evt.feature);
       });
 
-      this.activeInteractions = [draw,];
+      this.activeInteractions = [draw];
     }
 
     if (this.activeInteractions) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,9 +5,21 @@ export const SOURCE_VERSION_KEY = 'bnd:source-version';
 export const TITLE_KEY = 'bnd:title';
 export const DATA_VERSION_KEY = 'bnd:data-version';
 
+export const INTERACTIONS = {
+  modify: 'Modify',
+  select: 'Select',
+  point: 'Point',
+  line: 'LineString',
+  polygon: 'Polygon',
+};
+
+// useful for deciding what is or is not a drawing interaction
+INTERACTIONS.drawing = [INTERACTIONS.point, INTERACTIONS.line, INTERACTIONS.polygon];
+
 export default {
   LAYER_VERSION_KEY,
   SOURCE_VERSION_KEY,
   TITLE_KEY,
   DATA_VERSION_KEY,
+  INTERACTIONS,
 };

--- a/src/reducers/drawing.js
+++ b/src/reducers/drawing.js
@@ -1,0 +1,34 @@
+/** Drawing Reducer
+ *
+ *  This initiates drawing on the map and can track
+ *  changes as they are made.
+ *
+ */
+
+import { DRAWING } from '../action-types';
+
+const defaultState = {
+  interaction: null,
+  sourceName: null,
+};
+
+
+function startDrawing(state, action) {
+  return {
+    interaction: action.interaction,
+    sourceName: action.sourceName,
+  };
+}
+
+
+export default function drawingReducer(state = defaultState, action) {
+  switch (action.type) {
+    case DRAWING.END:
+      // when interaction is null, drawing should cease.
+      return { interaction: null, sourceName: null };
+    case DRAWING.START:
+      return startDrawing(state, action);
+    default:
+      return state;
+  }
+}

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -37,6 +37,10 @@ const config = {
       'webpack/hot/only-dev-server',
       './examples/paint-change/app.jsx',
     ],
+    'drawing': [
+      'webpack/hot/only-dev-server',
+      './examples/drawing/app.jsx',
+    ]
   },
   // Server Configuration options
   devServer: {


### PR DESCRIPTION
1. Added a special reducer/action set in order to handle
   the drawing functions (as they are not covered by mapbox gl styles).
2. Modified the map component to use drawing.interaction and drawing.sourceName
   props for identifying when a feature is being drawn and on to what.
3. Created an example app with a working demo that includes onFeatureDrawn
   which is the call back provided upon a features drawing completion.
4. Needed to add the canvas module to the dev dependencies.
   By default jsdom/enzyme/jest does not emulate the canvas, they
   depend on the canvas package. This may not be practical to install
   for all dev environments (looking at you, Windows) and may need to
   be shifted to a peerDependency.
5. The map has withRef: true in order to support introspection.

Refs: SDK-500, SDK-535