### PR TITLE
Added hash-based history tracking.

### DIFF
--- a/__tests__/actions/map.test.js
+++ b/__tests__/actions/map.test.js
@@ -28,7 +28,7 @@ describe('actions', () => {
     const name = 'New Name';
     const expectedAction = {
       type: MAP.SET_NAME,
-      name: { name },
+      name,
     };
     expect(actions.setMapName(name)).toEqual(expectedAction);
   });

--- a/__tests__/components/history.test.jsx
+++ b/__tests__/components/history.test.jsx
@@ -1,0 +1,91 @@
+/* global it, describe, expect, spyOn, beforeEach */
+
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import { createStore, combineReducers } from 'redux';
+import MapReducer from '../../src/reducers/map';
+import { setView } from '../../src/actions/map';
+
+import SdkHashHistory, { HashHistory } from '../../src/components/history';
+
+describe('test the HashHistory component', () => {
+  it('should render the components without error', () => {
+    shallow(<HashHistory />);
+  });
+
+  it('should change the window hash when x,y, or z change', () => {
+    const wrapper = shallow(<HashHistory />);
+
+    // defaults to center=[0,0], zoom=1
+    expect(window.location.hash).toBe('#x=0&y=0&z=1');
+
+    // update x
+    wrapper.setProps({ map: { center: [-1, 0], zoom: 1 } });
+    wrapper.update();
+    expect(window.location.hash).toBe('#x=-1&y=0&z=1');
+
+    // update y
+    wrapper.setProps({ map: { center: [-1, -1], zoom: 1 } });
+    wrapper.update();
+    expect(window.location.hash).toBe('#x=-1&y=-1&z=1');
+
+    // update z
+    wrapper.setProps({ map: { center: [-1, -1], zoom: 11 } });
+    wrapper.update();
+    expect(window.location.hash).toBe('#x=-1&y=-1&z=11');
+  });
+
+  it('should update the view when x,y,z changes', () => {
+    const props = {
+      setView: () => { },
+    };
+    spyOn(props, 'setView');
+    mount(<HashHistory {...props} />);
+
+    // simulate a hash change event.
+    window.location.hash = '#x=200&y=200&z=22';
+    window.dispatchEvent(new Event('hashchange'));
+
+    // setView is the function property to handle
+    //  changing the view when the hash has changed.
+    expect(props.setView).toHaveBeenCalled();
+  });
+
+  it('should fail gracefully when there is an invalid center value', () => {
+    mount(<HashHistory />);
+    expect(window.location.hash).toBe('#x=0&y=0&z=1');
+    window.location.hash = '#x=chicken&y=nuggets';
+    window.dispatchEvent(new Event('hashchange'));
+  });
+});
+
+describe('change the connected HashHistory', () => {
+  let store = null;
+
+  beforeEach(() => {
+    store = createStore(combineReducers({
+      map: MapReducer,
+    }));
+  });
+
+  it('sets the view when the hash changes', () => {
+    // mount a connected HashHistory component.
+    mount(<SdkHashHistory store={store} />);
+
+    // simulate a hash change event.
+    window.location.hash = '#x=200&y=200&z=22';
+    window.dispatchEvent(new Event('hashchange'));
+
+    const st = store.getState();
+    expect(st.map.center).toEqual([200, 200]);
+    expect(st.map.zoom).toEqual(22);
+  });
+
+  it('changes the hash when the view changes', () => {
+    // mount a connected HashHistory component.
+    mount(<SdkHashHistory store={store} />);
+    store.dispatch(setView([100, 100], 10));
+    expect(window.location.hash).toBe('#x=100&y=100&z=10');
+  });
+});

--- a/__tests__/components/history.test.jsx
+++ b/__tests__/components/history.test.jsx
@@ -18,22 +18,22 @@ describe('test the HashHistory component', () => {
     const wrapper = shallow(<HashHistory />);
 
     // defaults to center=[0,0], zoom=1
-    expect(window.location.hash).toBe('#x=0&y=0&z=1');
+    expect(window.location.hash).toBe('#x=0&y=0&z=1&r=0');
 
     // update x
     wrapper.setProps({ map: { center: [-1, 0], zoom: 1 } });
     wrapper.update();
-    expect(window.location.hash).toBe('#x=-1&y=0&z=1');
+    expect(window.location.hash).toBe('#x=-1&y=0&z=1&r=0');
 
     // update y
     wrapper.setProps({ map: { center: [-1, -1], zoom: 1 } });
     wrapper.update();
-    expect(window.location.hash).toBe('#x=-1&y=-1&z=1');
+    expect(window.location.hash).toBe('#x=-1&y=-1&z=1&r=0');
 
     // update z
     wrapper.setProps({ map: { center: [-1, -1], zoom: 11 } });
     wrapper.update();
-    expect(window.location.hash).toBe('#x=-1&y=-1&z=11');
+    expect(window.location.hash).toBe('#x=-1&y=-1&z=11&r=0');
   });
 
   it('should update the view when x,y,z changes', () => {
@@ -44,7 +44,7 @@ describe('test the HashHistory component', () => {
     mount(<HashHistory {...props} />);
 
     // simulate a hash change event.
-    window.location.hash = '#x=200&y=200&z=22';
+    window.location.hash = '#x=200&y=200&z=22&r=0';
     window.dispatchEvent(new Event('hashchange'));
 
     // setView is the function property to handle
@@ -54,7 +54,7 @@ describe('test the HashHistory component', () => {
 
   it('should fail gracefully when there is an invalid center value', () => {
     mount(<HashHistory />);
-    expect(window.location.hash).toBe('#x=0&y=0&z=1');
+    expect(window.location.hash).toBe('#x=0&y=0&z=1&r=0');
     window.location.hash = '#x=chicken&y=nuggets';
     window.dispatchEvent(new Event('hashchange'));
   });
@@ -74,7 +74,7 @@ describe('change the connected HashHistory', () => {
     mount(<SdkHashHistory store={store} />);
 
     // simulate a hash change event.
-    window.location.hash = '#x=200&y=200&z=22';
+    window.location.hash = '#x=200&y=200&z=22&r=0';
     window.dispatchEvent(new Event('hashchange'));
 
     const st = store.getState();
@@ -86,6 +86,6 @@ describe('change the connected HashHistory', () => {
     // mount a connected HashHistory component.
     mount(<SdkHashHistory store={store} />);
     store.dispatch(setView([100, 100], 10));
-    expect(window.location.hash).toBe('#x=100&y=100&z=10');
+    expect(window.location.hash).toBe('#x=100&y=100&z=10&r=0');
   });
 });

--- a/__tests__/root/util.test.js
+++ b/__tests__/root/util.test.js
@@ -41,4 +41,16 @@ describe('util', () => {
     expect(util.jsonEquals(paint, new_paint)).toEqual(false);
     expect(util.jsonEquals(paint, same_paint)).toEqual(true);
   });
+
+  it('parses aand deodes a query string', () => {
+    const query_string = 'what=%2Fis%20slash&roses=3000';
+    const parsed = {
+      what: '/is slash',
+      roses: '3000',
+    };
+
+    expect(util.parseQueryString(query_string)).toEqual(parsed);
+
+    expect(util.encodeQueryObject(parsed)).toBe(query_string);
+  });
 });

--- a/__tests__/root/util.test.js
+++ b/__tests__/root/util.test.js
@@ -42,7 +42,7 @@ describe('util', () => {
     expect(util.jsonEquals(paint, same_paint)).toEqual(true);
   });
 
-  it('parses aand deodes a query string', () => {
+  it('parses and decodes a query string', () => {
     const query_string = 'what=%2Fis%20slash&roses=3000';
     const parsed = {
       what: '/is slash',

--- a/examples/basic/app.jsx
+++ b/examples/basic/app.jsx
@@ -7,17 +7,12 @@
 
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-/** Basic Application.
- *
- *  Creates a map with OSM tiles and a GeoJSON source
- *  and layer.
- *
- */
 
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 import SdkMap from '@boundlessgeo/sdk/components/map';
+import SdkHashHistory from '@boundlessgeo/sdk/components/history';
 import SdkMapReducer from '@boundlessgeo/sdk/reducers/map';
 import * as mapActions from '@boundlessgeo/sdk/actions/map';
 
@@ -269,6 +264,8 @@ function main() {
       <button className="sdk-btn blue" onClick={removeRandomPoints}>Remove random points</button>
       <button className="sdk-btn" onClick={updateMinzoom}>Update Min Zoom</button>
       <InputField />
+
+      <SdkHashHistory store={store} />
     </div>
   ), document.getElementById('controls'));
 }

--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -16,7 +16,7 @@ export function setView(center, zoom) {
 export function setMapName(name) {
   return {
     type: MAP.SET_NAME,
-    name: { name },
+    name,
   };
 }
 

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -1,0 +1,152 @@
+/** Track the history of the map in the history.
+ *
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { setView } from '../actions/map';
+import { parseQueryString, encodeQueryObject } from '../util';
+
+function proposeFloat(value, defaultValue) {
+  const proposed = parseFloat(value);
+  if (typeof proposed === 'number' && isFinite(proposed)) {
+    return proposed;
+  }
+  return defaultValue;
+}
+
+export class HashHistory extends React.Component {
+  /** Ensure the hash is restored if already set
+   */
+  componentWillMount() {
+    // without this, render() will overwrite what is in the URL.
+    this.onHashChange();
+  }
+
+  /** After the component has mounted,
+   *  add a listener for the history changes.
+   */
+  componentDidMount() {
+    // addEventListener is supported in IE9+
+    window.addEventListener('hashchange', () => {
+      this.onHashChange();
+    });
+  }
+
+  shouldComponentUpdate(nextProps) {
+    // this only listens for the center and zoom
+    //  to change but props.map contains a lot more data.
+    return (
+      this.props.map.center[0] !== nextProps.map.center[0]
+      || this.props.map.center[1] !== nextProps.map.center[1]
+      || this.props.map.zoom !== nextProps.map.zoom
+    );
+  }
+
+  /** When the hash changes, attempt to parse a location
+   *  from the URL.
+   */
+  onHashChange() {
+    // get the hash and remove the leading '#'
+    const hash = window.location.hash.substring(1);
+    const parsed_hash = parseQueryString(hash);
+
+    // pass along the now parsed hash to the delegate functions.
+    this.parseLocationHash(parsed_hash);
+  }
+
+  /** Encode the location in an object appropriate
+   *  for hash-encoding.
+   *
+   *  @returns an Object with x,y,z members.
+   */
+  getLocationStateObject() {
+    return {
+      x: this.props.map.center[0],
+      y: this.props.map.center[1],
+      z: this.props.map.zoom,
+    };
+  }
+
+  /** Create an object which will be encoded in the hash
+   *
+   *  This object should represent a limited amount of state
+   *  which is appropriate for hash-encoding.
+   *
+   */
+  getStateObject() {
+    return Object.assign(
+      {},
+      this.getLocationStateObject(),
+    );
+  }
+
+  /** Parse the location from the hash.
+   *
+   *  @param parsedHash The object resulting from parseQueryString of the hash.
+   *
+   */
+  parseLocationHash(parsedHash) {
+    // create copies of the current center and zoom
+    const center = this.props.map.center.slice();
+    let zoom = 0 + this.props.map.zoom;
+
+    center[0] = proposeFloat(parsedHash.x, center[0]);
+    center[1] = proposeFloat(parsedHash.y, center[1]);
+    zoom = proposeFloat(parsedHash.z, zoom);
+
+    // change the view.
+    this.props.setView(center, zoom);
+  }
+
+  /** Encode the state for the URL hash.
+   */
+  encodeState() {
+    const st = this.getStateObject();
+    return encodeQueryObject(st);
+  }
+
+  render() {
+    // set the hash as appropriate.
+    window.location.hash = `#${this.encodeState()}`;
+
+    // this doesn't actually contribute anything to the DOM!
+    return false;
+  }
+}
+
+HashHistory.propTypes = {
+  map: PropTypes.shape({
+    center: PropTypes.arrayOf(PropTypes.number),
+    zoom: PropTypes.number,
+  }),
+  setView: PropTypes.func,
+};
+
+
+HashHistory.defaultProps = {
+  map: {
+    center: [0, 0],
+    zoom: 1,
+  },
+  setView: () => {
+  },
+};
+
+function mapStateToProps(state) {
+  return {
+    map: state.map,
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    setView: (center, zoom) => {
+      dispatch(setView(center, zoom));
+    },
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(HashHistory);

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -1,4 +1,4 @@
-/** Track the history of the map in the history.
+/** Track the history of the map in the hash.
  *
  */
 

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -42,6 +42,7 @@ export class HashHistory extends React.Component {
       this.props.map.center[0] !== nextProps.map.center[0]
       || this.props.map.center[1] !== nextProps.map.center[1]
       || this.props.map.zoom !== nextProps.map.zoom
+      || this.props.map.rotation !== nextProps.map.rotation
     );
   }
 
@@ -67,6 +68,7 @@ export class HashHistory extends React.Component {
       x: this.props.map.center[0],
       y: this.props.map.center[1],
       z: this.props.map.zoom,
+      r: this.props.map.rotation ? this.props.map.rotation : 0,
     };
   }
 
@@ -90,15 +92,17 @@ export class HashHistory extends React.Component {
    */
   parseLocationHash(parsedHash) {
     // create copies of the current center and zoom
-    const center = this.props.map.center.slice();
-    let zoom = 0 + this.props.map.zoom;
+    const center = this.props.map.center;
 
-    center[0] = proposeFloat(parsedHash.x, center[0]);
-    center[1] = proposeFloat(parsedHash.y, center[1]);
-    zoom = proposeFloat(parsedHash.z, zoom);
+    const new_center = [
+      proposeFloat(parsedHash.x, center[0]),
+      proposeFloat(parsedHash.y, center[1]),
+    ];
+
+    const zoom = proposeFloat(parsedHash.z, this.props.map.zoom);
 
     // change the view.
-    this.props.setView(center, zoom);
+    this.props.setView(new_center, zoom);
   }
 
   /** Encode the state for the URL hash.
@@ -121,6 +125,7 @@ HashHistory.propTypes = {
   map: PropTypes.shape({
     center: PropTypes.arrayOf(PropTypes.number),
     zoom: PropTypes.number,
+    rotation: PropTypes.number,
   }),
   setView: PropTypes.func,
 };
@@ -130,6 +135,7 @@ HashHistory.defaultProps = {
   map: {
     center: [0, 0],
     zoom: 1,
+    rotation: 0,
   },
   setView: () => {
   },

--- a/src/util.js
+++ b/src/util.js
@@ -52,3 +52,41 @@ export function getMax(...args) {
   if (numbers.length === 1) { return numbers[0]; }
   return Math.max.apply(this, getNumericValues(args));
 }
+
+/** Parse an arbitrary string as if it were a URL.
+ *
+ *  @param queryString {String} - The query string to parse.
+ *
+ * @returns An object with the key-value-pairs.
+ */
+export function parseQueryString(queryString) {
+  const pairs = queryString.split('&');
+  const results = {};
+  for (let i = 0, ii = pairs.length; i < ii; i++) {
+    // Using index of and substring has two advantages over split:
+    // 1. It more gracefully handles components which have a = in them erroneously.
+    // 2. It's slightly faster than using split.
+    const pos = pairs[i].indexOf('=');
+    const key = pairs[i].substring(0, pos);
+    const value = decodeURIComponent(pairs[i].substring(pos + 1));
+
+    results[key] = value;
+  }
+  return results;
+}
+
+/** Convert an object into a query string.
+ *
+ *  @param query {Object} - An object representing key-value-pairs to encode.
+ *
+ * @returns A URL encoded string.
+ */
+export function encodeQueryObject(query) {
+  const keys = Object.keys(query);
+  const pairs = [];
+  for (let i = 0, ii = keys.length; i < ii; i++) {
+    const value = encodeURIComponent(query[keys[i]]);
+    pairs.push(`${keys[i]}=${value}`);
+  }
+  return pairs.join('&');
+}


### PR DESCRIPTION
The "built-in" component only handles location
but is structured in such a way that it could
be extended to track more items.

To support this query-string handling functions have
been added to util.

The parseQueryString and encodeQueryObject are used
to convert URL encoded query strings to objects and vice-versa.

Refs: SDK-573