### PR TITLE
Fix setting the map name

### DIFF
--- a/examples/basic/app.jsx
+++ b/examples/basic/app.jsx
@@ -215,6 +215,8 @@ function main() {
     constructor(props) {
       super(props);
       this.state = { value: store.getState().map.name };
+      this.handleSubmit = this.handleSubmit.bind(this);
+      this.updateMapName = this.updateMapName.bind(this);
     }
     updateMapName(event) {
       this.setState({ value: event.target.value });


### PR DESCRIPTION
Setting the map name was broken in the basic example, this PR fixes it