### PR TITLE
Fixed setView projections bug.

### DIFF
--- a/__tests__/components/history.test.jsx
+++ b/__tests__/components/history.test.jsx
@@ -18,22 +18,22 @@ describe('test the HashHistory component', () => {
     const wrapper = shallow(<HashHistory />);
 
     // defaults to center=[0,0], zoom=1
-    expect(window.location.hash).toBe('#x=0&y=0&z=1&r=0');
+    expect(window.location.hash).toBe('#x=0.00000&y=0.00000&z=1&r=0');
 
     // update x
     wrapper.setProps({ map: { center: [-1, 0], zoom: 1 } });
     wrapper.update();
-    expect(window.location.hash).toBe('#x=-1&y=0&z=1&r=0');
+    expect(window.location.hash).toBe('#x=-1.00000&y=0.00000&z=1&r=0');
 
     // update y
     wrapper.setProps({ map: { center: [-1, -1], zoom: 1 } });
     wrapper.update();
-    expect(window.location.hash).toBe('#x=-1&y=-1&z=1&r=0');
+    expect(window.location.hash).toBe('#x=-1.00000&y=-1.00000&z=1&r=0');
 
     // update z
     wrapper.setProps({ map: { center: [-1, -1], zoom: 11 } });
     wrapper.update();
-    expect(window.location.hash).toBe('#x=-1&y=-1&z=11&r=0');
+    expect(window.location.hash).toBe('#x=-1.00000&y=-1.00000&z=11&r=0');
   });
 
   it('should update the view when x,y,z changes', () => {
@@ -54,7 +54,7 @@ describe('test the HashHistory component', () => {
 
   it('should fail gracefully when there is an invalid center value', () => {
     mount(<HashHistory />);
-    expect(window.location.hash).toBe('#x=0&y=0&z=1&r=0');
+    expect(window.location.hash).toBe('#x=0.00000&y=0.00000&z=1&r=0');
     window.location.hash = '#x=chicken&y=nuggets';
     window.dispatchEvent(new Event('hashchange'));
   });
@@ -86,6 +86,6 @@ describe('change the connected HashHistory', () => {
     // mount a connected HashHistory component.
     mount(<SdkHashHistory store={store} />);
     store.dispatch(setView([100, 100], 10));
-    expect(window.location.hash).toBe('#x=100&y=100&z=10&r=0');
+    expect(window.location.hash).toBe('#x=100.00000&y=100.00000&z=10&r=0');
   });
 });

--- a/__tests__/components/map.test.jsx
+++ b/__tests__/components/map.test.jsx
@@ -443,12 +443,12 @@ describe('Map component', () => {
 
     store.dispatch(MapActions.setView([-45, -45], 11));
 
-    sdk_map.map.getView().setCenter([45, 45]);
+    sdk_map.map.getView().setCenter([0, 0]);
     sdk_map.map.dispatchEvent({
       type: 'moveend',
     });
 
-    expect(store.getState().map.center).toEqual([45, 45]);
+    expect(store.getState().map.center).toEqual([0, 0]);
   });
 
   it('should trigger the popup-related callbacks', () => {

--- a/examples/basic/app.jsx
+++ b/examples/basic/app.jsx
@@ -27,7 +27,7 @@ const store = createStore(combineReducers({
 
 function main() {
   // Start with a reasonable global view of the map.
-  store.dispatch(mapActions.setView([-1759914.3204498321, 3236495.368492126], 2));
+  store.dispatch(mapActions.setView([-93, 45], 2));
 
   store.dispatch(mapActions.setMapName('Basic Map Example'));
 

--- a/examples/clustering/app.jsx
+++ b/examples/clustering/app.jsx
@@ -26,7 +26,7 @@ const store = createStore(combineReducers({
 
 function main() {
   // Start with a reasonable global view of hte map.
-  store.dispatch(mapActions.setView([-1759914.3204498321, 3236495.368492126], 2));
+  store.dispatch(mapActions.setView([-93, 45], 5));
 
   // add the OSM source
   store.dispatch(mapActions.addSource('osm', {

--- a/examples/drawing/app.jsx
+++ b/examples/drawing/app.jsx
@@ -28,7 +28,7 @@ const store = createStore(combineReducers({
 
 function main() {
   // Start with a reasonable global view of hte map.
-  store.dispatch(mapActions.setView([-1759914.3204498321, 3236495.368492126], 2));
+  store.dispatch(mapActions.setView([-15, 30], 2));
 
   // add the OSM source
   store.dispatch(mapActions.addSource('osm', {

--- a/examples/paint-change/app.jsx
+++ b/examples/paint-change/app.jsx
@@ -23,7 +23,7 @@ const store = createStore(combineReducers({
 
 function main() {
   // Start with a reasonable global view of the map.
-  store.dispatch(mapActions.setView([-1759914.3204498321, 3236495.368492126], 2));
+  store.dispatch(mapActions.setView([-15, 30], 2));
 
   // add the OSM source
   store.dispatch(mapActions.addSource('osm', {

--- a/examples/popups/app.jsx
+++ b/examples/popups/app.jsx
@@ -114,7 +114,7 @@ function addPoints(sourceName, n_points = 10) {
 
 function main() {
   // Start with a reasonable global view of the map.
-  store.dispatch(mapActions.setView([-1759914.3204498321, 3236495.368492126], 1));
+  store.dispatch(mapActions.setView([-15, 30], 2));
 
   // add the OSM source
   store.dispatch(mapActions.addSource('osm', {

--- a/examples/wms/app.jsx
+++ b/examples/wms/app.jsx
@@ -90,7 +90,7 @@ const store = createStore(combineReducers({
 
 function main() {
   // start in the middle of america
-  store.dispatch(mapActions.setView([-10895923.706980927, 4656189.67701237], 4));
+  store.dispatch(mapActions.setView([-98, 40], 4));
 
   // add the OSM source
   store.dispatch(mapActions.addSource('osm', {

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -65,8 +65,8 @@ export class HashHistory extends React.Component {
    */
   getLocationStateObject() {
     return {
-      x: this.props.map.center[0],
-      y: this.props.map.center[1],
+      x: this.props.map.center[0].toFixed(5),
+      y: this.props.map.center[1].toFixed(5),
       z: this.props.map.zoom,
       r: this.props.map.rotation ? this.props.map.rotation : 0,
     };


### PR DESCRIPTION
1. Updated the map component to normalize the center
   from 4326 and to set the center as 4326 when moveend
   is triggered.
2. Made a small tweak to the history component to prevent
   insignificant digits from floodings the hash-url.
3. Updated tests to conform to the new 4326 rule.
4. Updated the example applications to also use 4326 to
   set the view.

REFS: SDK-624