### PR TITLE
patch to read features from source data w/o addfeature action

### DIFF
--- a/src/components/map.jsx
+++ b/src/components/map.jsx
@@ -144,12 +144,9 @@ function configureMvtSource(glSource) {
 function updateGeojsonSource(olSource, glSource, opt_mapProjection = 'EPSG:3857') {
   // parse the new features,
 
-  let features;
+  const readFeatureOpt = { featureProjection: opt_mapProjection };
 
-  if (glSource.data.features) {
-    const readFeatureOpt = { featureProjection: opt_mapProjection };
-    features = GEOJSON_FORMAT.readFeatures(glSource.data, readFeatureOpt);
-  }
+  const features = GEOJSON_FORMAT.readFeatures(glSource.data, readFeatureOpt);
 
   let vector_src = olSource;
 
@@ -166,10 +163,8 @@ function updateGeojsonSource(olSource, glSource, opt_mapProjection = 'EPSG:3857'
   // clear the layer WITHOUT dispatching remove events.
   vector_src.clear(true);
 
-  if (features) {
-    // bulk load the feature data
-    vector_src.addFeatures(features);
-  }
+  // bulk load the feature data
+  vector_src.addFeatures(features);
 }
 
 


### PR DESCRIPTION
basic app and sprites app are missing features on initial load w/o an addFeatures action specified in the apps, even when the feature data is populated in the addSource action.
this should restore the initial rendering of geojson layers w/ features.