### PR TITLE
Drop Canvas from devDeps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g++
   - "npm prune"
-  - npm install -g canvas
 
 before_script:
   - "export DISPLAY=:99.0"
+  - npm install canvas
 
 script:
   - "npm run test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g++
-  - npm install canvas
+  - npm install -g canvas
   - "npm prune"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g++
+  - npm install canvas
   - "npm prune"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g++
-  - npm install -g canvas
   - "npm prune"
+  - npm install -g canvas
 
 before_script:
   - "export DISPLAY=:99.0"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ http://localhost:3000/build/examples - browse to examples
 ## Troubleshooting
 
 If `npm start` fails review node version, SDK targets v6.0 or greater.  On OSX node install can be error prone, seems to work best when installed by Brew http://brewformulas.org/Node
+
+## Running tests
+
+The test suite will skip a number of tests unless the `canvas` module has been installed.
+
+For more details on installing `canvas` and other important developer notes
+please read [DEVELOPING.md](DEVELOPING.md).

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "canvas": "^1.6.5",
     "coveralls": "^2.13.1",
     "css-loader": "^0.28.4",
     "deep-freeze": "0.0.1",


### PR DESCRIPTION
Installing the canvas module has system requirements that
are not universally necessary for INSTALLING SDK.  They are
really only useful for running the test suite.

The tests which use canvas have checks to see if it is installed
making it, essentially, an optional install.