### PR TITLE
Adding export map action to Upload App

### DIFF
--- a/examples/upload-map/app.js
+++ b/examples/upload-map/app.js
@@ -53,7 +53,7 @@ function main() {
     <div>
       <ContextSelector store={store} />
       <h1>Save a Map</h1>
-      <h2>To .json:</h2>
+      <h2>To <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/">MapBox Style Specification</a></h2>
       <button className="sdk-btn" onClick={exportMapSpec}>Save Map</button>
     </div>
   ), document.getElementById('controls'));

--- a/examples/upload-map/app.js
+++ b/examples/upload-map/app.js
@@ -1,3 +1,4 @@
+/* global saveAs */
 /** Demo adding a map through mapbox style and exporting the map's endpoints to a file.
  *
  */
@@ -33,6 +34,13 @@ function main() {
     },
   }));
 
+  const exportMapSpec = () => {
+    const map_spec = store.getState().map;
+    const text = JSON.stringify(map_spec);
+    const file = new File([text], 'my_map', {type: "application/json"});
+    saveAs(file, 'my_map.json');
+  };
+
   // place the map on the page.
   ReactDOM.render(
     <SdkMap
@@ -44,6 +52,9 @@ function main() {
   ReactDOM.render((
     <div>
       <ContextSelector store={store} />
+      <h1>Save a Map</h1>
+      <h2>To .json:</h2>
+      <button className="sdk-btn" onClick={exportMapSpec}>Save Map</button>
     </div>
   ), document.getElementById('controls'));
 }

--- a/examples/upload-map/context-selector.js
+++ b/examples/upload-map/context-selector.js
@@ -107,7 +107,7 @@ class ContextSelector extends React.PureComponent {
           </div>
           <div className="drop">
             <h2>Via File Upload:</h2>
-            <label htmlFor="file_upload" onClick={this.clearError}>Choose a file to upload (.JSON)</label>
+            <label htmlFor="file_upload" onClick={this.clearError}>Choose a file to upload (.json)</label>
             <input id="file_upload" type="file" accept=".json" onChange={this.dropFiles}/>
           </div>
         </div>

--- a/examples/upload-map/index.html
+++ b/examples/upload-map/index.html
@@ -4,6 +4,8 @@ title: Upload Map Example
 shortdesc: Demonstrates Uploading a Mapbox Style Document.
 docs: >
   <li>Uploading Mapbox GL Style specifications through either URL or file options.</li>
+resources:
+  - https://unpkg.com/browser-filesaver@1.1.1/FileSaver.js
 ---
 <div id="map"></div>
 <div id="controls"></div>


### PR DESCRIPTION
save button saves map spec to .json file - i added it to this app so you can demo saving a spec file, altering it, and re-uploading it into the app.

JIRA SDK 554 - the jira ticket mentions wmc format but this button saves the file as .json, per talks w/ Walker and the team. 

Right now the whole map state is saved but if less or more info is needed for the map state - ie, state.map.sprite? - let me know.