### PR TITLE
Updates to ready NPM Publishing

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>{{ title }}</title>
-    <link rel="stylesheet" type="text/css" href="/dist/sdk.css"/>
+    <link rel="stylesheet" type="text/css" href="../../stylesheet/sdk.css"/>
     <link rel="stylesheet" type="text/css" href="../examples.css"/>
     {{{ extraHead.local }}}
     {{{ css.tag }}}

--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
     "test:watch": "npm test -- --watch",
     "lint": "eslint __tests__ src examples tasks",
     "cover": "node_modules/.bin/jest --coverage",
+    "sass": "node-sass --include-path ./node_modules ./src/stylesheet/sdk.scss",
     "build:examples": "node tasks/build-examples.js",
+    "build:examples-js": "webpack --config ./webpack-dev-server.config.js",
+    "build:css": "npm run sass -- -o ./build/stylesheet",
+    "bundle-examples": "npm run build:examples && npm run build:examples-js && npm run build:css",
     "build:js": "babel ./src --out-dir ./dist",
     "watch:js": "babel --watch ./src --out-dir ./dist",
-    "dist:examples": "node tasks/build-examples.js ./dist/examples",
-    "dist:copy": "node tasks/dist-copy.js",
-    "build:dist": "npm run build:js && npm run dist:copy && npm run dist:examples"
+    "dist:copy": "node tasks/dist-copy.js && node tasks/create-package-json.js",
+    "dist": "npm run build:js && npm run dist:copy"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/stylesheet/sdk.scss
+++ b/src/stylesheet/sdk.scss
@@ -1,7 +1,7 @@
 /*
  * Include the SDK stylesheet
  */
-@import '~ol/ol.css';
+@import 'ol/ol';
 @import 'popup';
 
 $sdk-orange: #f58d50;

--- a/tasks/create-package-json.js
+++ b/tasks/create-package-json.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var fsx = require('fs-extra');
 
-/** Make a reduced veersion of the package.json file
+/** Make a reduced version of the package.json file
  *  that is more appropriate for distribution.
  */
 

--- a/tasks/create-package-json.js
+++ b/tasks/create-package-json.js
@@ -1,0 +1,70 @@
+var path = require('path');
+var fsx = require('fs-extra');
+
+/** Make a reduced veersion of the package.json file
+ *  that is more appropriate for distribution.
+ */
+
+function main() {
+  return new Promise((resolve) => {
+    fsx.readFile(path.resolve(__dirname, '../package.json'), 'utf8', (err, data) => {
+      if (err) {
+        throw err;
+      }
+
+      resolve(data);
+    });
+  })
+  .then((data) => JSON.parse(data))
+  .then((packageData) => {
+    const {
+      author,
+      version,
+      description,
+      keywords,
+      repository,
+      license,
+      bugs,
+      homepage,
+      peerDependencies,
+      dependencies,
+    } = packageData;
+
+    const minimalPackage = {
+      name: '@boundlessgeo/sdk',
+      author,
+      version,
+      description,
+      keywords,
+      repository,
+      license,
+      bugs,
+      homepage,
+      peerDependencies,
+      dependencies,
+    };
+
+    return new Promise((resolve) => {
+      const buildPath = path.resolve(__dirname, '../dist/package.json');
+      const data = JSON.stringify(minimalPackage, null, 2);
+      fsx.writeFile(buildPath, data, (err) => {
+        if (err) throw (err);
+        console.log(`Created package.json in ${buildPath}`);
+        resolve();
+      });
+    });
+  });
+}
+
+if (require.main === module) {
+  main((err) => {
+    if (err) {
+      process.stderr.write(`Creating dist package.json failed. See the full trace below.\n\n ${err.stack} \n`);
+      process.exit(1);
+    } else {
+      process.exit(0);
+    }
+  });
+}
+
+module.exports = main;

--- a/tasks/create-package-json.js
+++ b/tasks/create-package-json.js
@@ -49,7 +49,7 @@ function main() {
       const data = JSON.stringify(minimalPackage, null, 2);
       fsx.writeFile(buildPath, data, (err) => {
         if (err) throw (err);
-        console.log(`Created package.json in ${buildPath}`);
+        process.stdout.write(`Created package.json in ${buildPath}\n`);
         resolve();
       });
     });

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -51,7 +51,7 @@ const config = {
     filename: 'build/examples/[name]/[name].bundle.js',
   },
   plugins: [
-    new ExtractTextPlugin('dist/sdk.css'),
+    new ExtractTextPlugin('sdk.css'),
     // Enables Hot Modules Replacement
     new webpack.HotModuleReplacementPlugin(),
   ],


### PR DESCRIPTION
1. Made sdk path relative.
2. Created new "bundle-examples" script which:
  a. Builds the Examples HTML
  b. Builds a static CSS file for the examples
  c. Outputs the individual bundles per example.

  This allows the examples to be served from a static directory
  or non-Webpack-based server.
3. npm run dist will now output a babelified version
   of SDK with the SASS stylesheet and a more appropriate package.json.

   I've tested this using `yarn add file:...` with the rest of the quickstart
   instructions.