### PR TITLE
Correction for Sass Loader to include node_modules

### DIFF
--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -51,7 +51,7 @@ const config = {
     filename: 'build/examples/[name]/[name].bundle.js',
   },
   plugins: [
-    new ExtractTextPlugin('sdk.css'),
+    new ExtractTextPlugin('build/stylesheet/sdk.css'),
     // Enables Hot Modules Replacement
     new webpack.HotModuleReplacementPlugin(),
   ],
@@ -68,7 +68,12 @@ const config = {
         test: /\.s?css$/,
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
-          use: ['css-loader', 'sass-loader']
+          use: ['css-loader', {
+            loader: 'sass-loader',
+            options: {
+              includePaths: ['node_modules'],
+            }
+          }],
         }),
 
       }


### PR DESCRIPTION
The ol CSS inclusion was using a ".css" import which was
not inlining the ol CSS. Yesterday, that was changed to properly inline
the OL CSS when doing `npm run build:css` but the webpack configuration
was missing the necessary new includePaths.