### PR TITLE
Add initial TIME parameter for WMS sources

### DIFF
--- a/__tests__/components/map-time.test.js
+++ b/__tests__/components/map-time.test.js
@@ -40,4 +40,33 @@ describe('Map component time tests', () => {
     params = source.getParams();
     expect(params.TIME).toBe('2006-06-23T03:10:00Z');
   });
+
+  it('should correctly set TIME param if source added after setMapTime', () => {
+    const store = createStore(combineReducers({
+      map: MapReducer,
+    }));
+
+    const wrapper = mount(<ConnectedMap store={store} />);
+    const map = wrapper.instance().getWrappedInstance();
+
+    store.dispatch(MapActions.setView([-98, 40], 4));
+    store.dispatch(MapActions.setMapTime('2006-06-23T03:10:00Z'));
+
+    const getMapUrl = 'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=TRUE&SRS=EPSG:900913&LAYERS=nexrad-n0r-wmst&STYLES=&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}';
+    store.dispatch(MapActions.addSource('mesonet', {
+      type: 'raster',
+      tileSize: 256,
+      tiles: [getMapUrl],
+    }));
+    store.dispatch(MapActions.addLayer({
+      id: 'nexrad',
+      source: 'mesonet',
+    }));
+    store.dispatch(MapActions.setLayerTime('nexrad', '1995-01-01/2017-12-31/PT5M'));
+
+    let layers = map.map.getLayers().getArray();
+    const source = layers[0].getSource();
+    const params = source.getParams();
+    expect(params.TIME).toBe('2006-06-23T03:10:00Z');
+  });
 });

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -84,7 +84,7 @@ function getVersion(obj, key) {
   return obj.metadata[key];
 }
 
-function configureTileSource(glSource, mapProjection) {
+function configureTileSource(glSource, mapProjection, time) {
   const tile_url = glSource.tiles[0];
   const commonProps = {
     attributions: glSource.attribution,
@@ -103,6 +103,9 @@ function configureTileSource(glSource, mapProjection) {
       if (keys[i].toUpperCase() === 'REQUEST') {
         delete params[keys[i]];
       }
+    }
+    if (time) {
+      params.TIME = time;
     }
     return new TileWMSSource(Object.assign({
       url: urlParts[0],
@@ -276,11 +279,11 @@ function configureGeojsonSource(glSource, mapProjection, baseUrl) {
   return new_src;
 }
 
-function configureSource(glSource, mapProjection, accessToken, baseUrl) {
+function configureSource(glSource, mapProjection, accessToken, baseUrl, time) {
   // tiled raster layer.
   if (glSource.type === 'raster') {
     if ('tiles' in glSource) {
-      return configureTileSource(glSource, mapProjection);
+      return configureTileSource(glSource, mapProjection, time);
     } else if (glSource.url) {
       return configureTileJSONSource(glSource);
     }
@@ -527,8 +530,9 @@ export class Map extends React.Component {
       // Add the source because it's not in the current
       //  list of sources.
       if (!(src_name in this.sources)) {
+        const time = this.props.map.metadata ? this.props.map.metadata[TIME_KEY] : null;
         this.sources[src_name] = configureSource(sourcesDef[src_name], proj,
-          this.props.accessToken, this.props.baseUrl);
+          this.props.accessToken, this.props.baseUrl, time);
       }
 
       // Check to see if there was a clustering change.


### PR DESCRIPTION
If the map time was set before adding the source, the TIME parameter would not getting set.