### PR TITLE
Allow time filtering of vector layers

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,7 @@ export const LAYER_VERSION_KEY = 'bnd:layer-version';
 export const SOURCE_VERSION_KEY = 'bnd:source-version';
 export const TITLE_KEY = 'bnd:title';
 export const TIME_KEY = 'bnd:time';
+export const TIME_ATTRIBUTE_KEY = 'bnd:timeattribute';
 export const DATA_VERSION_KEY = 'bnd:data-version';
 
 export const INTERACTIONS = {
@@ -45,6 +46,7 @@ export default {
   SOURCE_VERSION_KEY,
   TITLE_KEY,
   TIME_KEY,
+  TIME_ATTRIBUTE_KEY,
   DATA_VERSION_KEY,
   INTERACTIONS,
 };


### PR DESCRIPTION
SDK-650
Since it was necessary for replicating this example: https://www.mapbox.com/mapbox-gl-js/example/timeline-animation/ this PR also introduced a prop on the map component to configure wrapX