### PR TITLE
Adding a toLower to protect source typos ie - geoJson

### DIFF
--- a/__tests__/actions/map.test.js
+++ b/__tests__/actions/map.test.js
@@ -75,6 +75,23 @@ describe('actions', () => {
     expect(actions.addSource(sourceName, sourceDef)).toEqual(expectedAction);
   });
 
+  it('should create an action to add a source of a bad type and error', () => {
+    const sourceName = 'osm';
+    const sourceDef = {
+      type: 'xraster',
+      attribution: '&copy; <a href=\'https://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors.',
+      tileSize: 256,
+      tiles: [
+        'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      ],
+    };
+
+    const errorMsg = 'Invalid source type: xraster.  Valid source types are vector,raster,geojson,image,video,canvas';
+    expect(() => {actions.addSource(sourceName, sourceDef)} ).toThrow(new Error(errorMsg));
+  });
+
   it('should create an action to remove a layer', () => {
     const layerId = 'osm';
     const expectedAction = {

--- a/__tests__/components/map-geojson-source.test.js
+++ b/__tests__/components/map-geojson-source.test.js
@@ -55,30 +55,19 @@ describe('tests for the geojson-type map sources', () => {
     }, 100);
   }
 
-  function testGeoJsonData(done, data, nFeatures) {
-    const src_name = 'test-source';
-    store.dispatch(MapActions.addSource(src_name, {
-      type: 'geoJson',
-      data,
-    }));
-
-    // check to see if the map source is now defined.
-    expect(map.sources[src_name]).not.toBe(undefined);
-
-    // check the feature count matches.
-    setTimeout(() => {
-      const src = map.sources[src_name];
-      expect(src.getFeatures().length).toBe(nFeatures);
-      done();
-    }, 100);
-  }
-
   it('handles undefined data', (done) => {
     testGeojsonData(done, undefined, 0);
   });
 
-  it('handles mixed case type - geoJson', (done) => {
-    testGeoJsonData(done, {}, 0);
+  it('handles mixed case type - geoJson', () => {
+    const src_name = 'test-source';
+    store.dispatch(MapActions.addSource(src_name, {
+      type: 'geoJson',
+      data : {},
+    }));
+
+    // check to see if the map source is now undefined.
+    expect(map.sources[src_name]).toBe(undefined);
   });
 
   it('adds a geojson source with an empty object', (done) => {

--- a/__tests__/components/map-geojson-source.test.js
+++ b/__tests__/components/map-geojson-source.test.js
@@ -59,17 +59,6 @@ describe('tests for the geojson-type map sources', () => {
     testGeojsonData(done, undefined, 0);
   });
 
-  it('handles mixed case type - geoJson', () => {
-    const src_name = 'test-source';
-    store.dispatch(MapActions.addSource(src_name, {
-      type: 'geoJson',
-      data : {},
-    }));
-
-    // check to see if the map source is now undefined.
-    expect(map.sources[src_name]).toBe(undefined);
-  });
-
   it('adds a geojson source with an empty object', (done) => {
     testGeojsonData(done, {}, 0);
   });

--- a/__tests__/components/map-geojson-source.test.js
+++ b/__tests__/components/map-geojson-source.test.js
@@ -55,8 +55,30 @@ describe('tests for the geojson-type map sources', () => {
     }, 100);
   }
 
+  function testGeoJsonData(done, data, nFeatures) {
+    const src_name = 'test-source';
+    store.dispatch(MapActions.addSource(src_name, {
+      type: 'geoJson',
+      data,
+    }));
+
+    // check to see if the map source is now defined.
+    expect(map.sources[src_name]).not.toBe(undefined);
+
+    // check the feature count matches.
+    setTimeout(() => {
+      const src = map.sources[src_name];
+      expect(src.getFeatures().length).toBe(nFeatures);
+      done();
+    }, 100);
+  }
+
   it('handles undefined data', (done) => {
     testGeojsonData(done, undefined, 0);
+  });
+
+  it('handles mixed case type - geoJson', (done) => {
+    testGeoJsonData(done, {}, 0);
   });
 
   it('adds a geojson source with an empty object', (done) => {

--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -19,6 +19,15 @@ import fetch from 'isomorphic-fetch';
 import { MAP } from '../action-types';
 import { TITLE_KEY, TIME_KEY } from '../constants';
 
+const sourceTypes = [
+  'vector',
+  'raster',
+  'geojson',
+  'image',
+  'video',
+  'canvas'
+];
+
 export function setView(center, zoom) {
   return {
     type: MAP.SET_VIEW,
@@ -50,6 +59,9 @@ export function addLayer(layerDef, layerTitle, positionId) {
 }
 
 export function addSource(sourceName, sourceDef) {
+  if (sourceTypes.indexOf(sourceDef.type) === -1 ) {
+    throw(new Error("Invalid source type: " + sourceDef.type + ".  Valid source types are " + sourceTypes.toString()));
+  }
   return {
     type: MAP.ADD_SOURCE,
     sourceName,

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -38,6 +38,15 @@ const defaultState = {
   layers: [],
 };
 
+const sourceTypes = [
+  'vector',
+  'raster',
+  'geojson',
+  'image',
+  'video',
+  'canvas'
+];
+
 function getVersion(metadata, version) {
   if (typeof (metadata) === 'undefined' || typeof (metadata[version]) === 'undefined') {
     return 0;
@@ -180,28 +189,31 @@ function updateLayer(state, action) {
  */
 function addSource(state, action) {
   const new_source = {};
-  // psudo error handling forcing type to lower to avoid mixed case geoJson
-  const sourceDef = Object.assign({}, action.sourceDef, {type:action.sourceDef.type.toLowerCase()});
 
-  new_source[action.sourceName] = Object.assign({}, sourceDef);
-  if (sourceDef.type === 'geojson') {
-    if (sourceDef.data === undefined || sourceDef.data === null) {
-      new_source[action.sourceName].data = {};
-    } else if (typeof sourceDef.data === 'object') {
-      new_source[action.sourceName].data = Object.assign({}, sourceDef.data);
-    } else {
-      new_source[action.sourceName].data = sourceDef.data;
+  if (sourceTypes.indexOf(action.sourceDef.type) === -1) {
+    new Error("Invalid source type: " + action.sourceDef.type);
+    return state;
+  } else {
+    new_source[action.sourceName] = Object.assign({}, action.sourceDef);
+    if (action.sourceDef.type === 'geojson') {
+      if (action.sourceDef.data === undefined || action.sourceDef.data === null) {
+        new_source[action.sourceName].data = {};
+      } else if (typeof action.sourceDef.data === 'object') {
+        new_source[action.sourceName].data = Object.assign({}, action.sourceDef.data);
+      } else {
+        new_source[action.sourceName].data = action.sourceDef.data;
+      }
     }
+
+    const new_metadata = {};
+    new_metadata[dataVersionKey(action.sourceName)] = 0;
+
+    const new_sources = Object.assign({}, state.sources, new_source);
+    return Object.assign({}, state, {
+      metadata: Object.assign({}, state.metadata, new_metadata),
+      sources: new_sources,
+    }, incrementVersion(state.metadata, SOURCE_VERSION_KEY));
   }
-
-  const new_metadata = {};
-  new_metadata[dataVersionKey(action.sourceName)] = 0;
-
-  const new_sources = Object.assign({}, state.sources, new_source);
-  return Object.assign({}, state, {
-    metadata: Object.assign({}, state.metadata, new_metadata),
-    sources: new_sources,
-  }, incrementVersion(state.metadata, SOURCE_VERSION_KEY));
 }
 
 /** Remove a source from the state.

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -38,15 +38,6 @@ const defaultState = {
   layers: [],
 };
 
-const sourceTypes = [
-  'vector',
-  'raster',
-  'geojson',
-  'image',
-  'video',
-  'canvas'
-];
-
 function getVersion(metadata, version) {
   if (typeof (metadata) === 'undefined' || typeof (metadata[version]) === 'undefined') {
     return 0;
@@ -190,30 +181,26 @@ function updateLayer(state, action) {
 function addSource(state, action) {
   const new_source = {};
 
-  if (sourceTypes.indexOf(action.sourceDef.type) === -1) {
-    new Error("Invalid source type: " + action.sourceDef.type);
-    return state;
-  } else {
-    new_source[action.sourceName] = Object.assign({}, action.sourceDef);
-    if (action.sourceDef.type === 'geojson') {
-      if (action.sourceDef.data === undefined || action.sourceDef.data === null) {
-        new_source[action.sourceName].data = {};
-      } else if (typeof action.sourceDef.data === 'object') {
-        new_source[action.sourceName].data = Object.assign({}, action.sourceDef.data);
-      } else {
-        new_source[action.sourceName].data = action.sourceDef.data;
-      }
+  new_source[action.sourceName] = Object.assign({}, action.sourceDef);
+  if (action.sourceDef.type === 'geojson') {
+    if (action.sourceDef.data === undefined || action.sourceDef.data === null) {
+      new_source[action.sourceName].data = {};
+    } else if (typeof action.sourceDef.data === 'object') {
+      new_source[action.sourceName].data = Object.assign({}, action.sourceDef.data);
+    } else {
+      new_source[action.sourceName].data = action.sourceDef.data;
     }
-
-    const new_metadata = {};
-    new_metadata[dataVersionKey(action.sourceName)] = 0;
-
-    const new_sources = Object.assign({}, state.sources, new_source);
-    return Object.assign({}, state, {
-      metadata: Object.assign({}, state.metadata, new_metadata),
-      sources: new_sources,
-    }, incrementVersion(state.metadata, SOURCE_VERSION_KEY));
   }
+
+  const new_metadata = {};
+  new_metadata[dataVersionKey(action.sourceName)] = 0;
+
+  const new_sources = Object.assign({}, state.sources, new_source);
+  return Object.assign({}, state, {
+    metadata: Object.assign({}, state.metadata, new_metadata),
+    sources: new_sources,
+  }, incrementVersion(state.metadata, SOURCE_VERSION_KEY));
+
 }
 
 /** Remove a source from the state.

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -180,14 +180,17 @@ function updateLayer(state, action) {
  */
 function addSource(state, action) {
   const new_source = {};
-  new_source[action.sourceName] = Object.assign({}, action.sourceDef);
-  if (action.sourceDef.type === 'geojson') {
-    if (action.sourceDef.data === undefined || action.sourceDef.data === null) {
+  // psudo error handling forcing type to lower to avoid mixed case geoJson
+  const sourceDef = Object.assign({}, action.sourceDef, {type:action.sourceDef.type.toLowerCase()});
+
+  new_source[action.sourceName] = Object.assign({}, sourceDef);
+  if (sourceDef.type === 'geojson') {
+    if (sourceDef.data === undefined || sourceDef.data === null) {
       new_source[action.sourceName].data = {};
-    } else if (typeof action.sourceDef.data === 'object') {
-      new_source[action.sourceName].data = Object.assign({}, action.sourceDef.data);
+    } else if (typeof sourceDef.data === 'object') {
+      new_source[action.sourceName].data = Object.assign({}, sourceDef.data);
     } else {
-      new_source[action.sourceName].data = action.sourceDef.data;
+      new_source[action.sourceName].data = sourceDef.data;
     }
   }
 


### PR DESCRIPTION
Adding test to make sure mixed case works
This could be changed to error once error handling is implemented, without this `type:geoJson` would work fine inside SDK/Redux but does nothing in Open Layer creating a confusing situation.  