### PR TITLE
Move sdk.css into examples directory

### DIFF
--- a/config/examples/example.html
+++ b/config/examples/example.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>{{ title }}</title>
-    <link rel="stylesheet" type="text/css" href="../../stylesheet/sdk.css"/>
+    <link rel="stylesheet" type="text/css" href="../sdk.css"/>
     <link rel="stylesheet" type="text/css" href="../examples.css"/>
     {{{ extraHead.local }}}
     {{{ css.tag }}}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:examples": "node tasks/build-examples.js",
     "build:hosted:examples": "node tasks/build-examples.js build/hosted/examples",
     "build:examples-js": "webpack --config ./webpack-example.config.js",
-    "build:css": "npm run sass -- -o ./build/hosted/stylesheet",
+    "build:css": "npm run sass -- -o ./build/hosted/examples",
     "bundle-examples": "npm run build:hosted:examples && npm run build:examples-js && npm run build:css",
     "build:js": "babel ./src --out-dir ./dist",
     "watch:js": "babel --watch ./src --out-dir ./dist",

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -35,7 +35,7 @@ const config = {
     filename: 'build/examples/[name]/[name].bundle.js',
   },
   plugins: [
-    new ExtractTextPlugin('build/stylesheet/sdk.css'),
+    new ExtractTextPlugin('build/examples/sdk.css'),
     // Enables Hot Modules Replacement
     new webpack.HotModuleReplacementPlugin(),
   ],

--- a/webpack-example.config.js
+++ b/webpack-example.config.js
@@ -23,7 +23,7 @@ const config = {
     filename: 'build/hosted/examples/[name]/[name].bundle.js',
   },
   plugins: [
-    new ExtractTextPlugin('build/hosted/stylesheet/sdk.css'),
+    new ExtractTextPlugin('build/hosted/examples/sdk.css'),
     new UglifyJSPlugin()
   ],
   module: {


### PR DESCRIPTION
Per the discussion in slack, I'm moving sdk.css into the examples directory