### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -867,11 +867,6 @@ export class Map extends React.Component {
       self.elems[id] = elem;
     }));
 
-
-    // move the element up a level to ensure
-    //  the rects are calculated correctly.
-    overlay.setElement(elem.firstChild);
-
     // set the popup id so we can match the component
     //  to the overlay.
     overlay.set('popupId', id);

--- a/src/components/wfs.js
+++ b/src/components/wfs.js
@@ -17,7 +17,7 @@
 
 import fetch from 'isomorphic-fetch';
 
-import { PureComponent } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 import WfsFormat from 'ol/format/wfs';
@@ -30,7 +30,7 @@ import { finishedAction } from '../actions/wfs';
 import { jsonClone } from '../util';
 import { WFS } from '../action-types';
 
-class WfsController extends PureComponent {
+class WfsController extends Component {
   constructor(props) {
     super(props);
     this.pendingActions = {};


### PR DESCRIPTION
This PR fixes 2 issues:

- DOM manipulation that seems unnecessary will break React 16, so let's fix it now already
- React 16 warns about PureComponent that uses shouldComponentUpdate