### PR TITLE
missed a typo/false test during geojson merge.

### DIFF
--- a/__tests__/components/map-geojson-source.test.js
+++ b/__tests__/components/map-geojson-source.test.js
@@ -156,6 +156,6 @@ describe('tests for the geojson-type map sources', () => {
       testGeojsonData(done, './test2.geojson', 2);
     };
 
-    testGeojsonData(done, '/bbox.geojson?BBOX={bbox-epsg-3857}', 2);
+    testGeojsonData(next_fetch, '/bbox.geojson?BBOX={bbox-epsg-3857}', 2);
   });
 });


### PR DESCRIPTION
I added this test at the last minute to quell a curiosity I had,
the test passed but was technically incorrect.  This fixes that
bug.