### PR TITLE
Fix for the loader not updating properly with GeoJson layers

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -236,7 +236,7 @@ function updateGeojsonSource(olSource, glSource, mapView, baseUrl) {
   }
 
   // update the loader function based on the glSource definition
-  src.set('loader', getLoaderFunction(glSource, mapView.getProjection, baseUrl));
+  src.loader_ = getLoaderFunction(glSource, mapView.getProjection(), baseUrl));
 
   // clear the layer WITHOUT dispatching remove events.
   src.clear(true);

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -236,7 +236,7 @@ function updateGeojsonSource(olSource, glSource, mapView, baseUrl) {
   }
 
   // update the loader function based on the glSource definition
-  src.loader_ = getLoaderFunction(glSource, mapView.getProjection(), baseUrl));
+  src.loader_ = getLoaderFunction(glSource, mapView.getProjection(), baseUrl);
 
   // clear the layer WITHOUT dispatching remove events.
   src.clear(true);


### PR DESCRIPTION
This more forcefully updates the loader using `loader_ =` instead of `set('loader',..` which didn't appear to actually work.