### PR TITLE
Wrote "npm link" how-to

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,5 +1,25 @@
 # Boundless SDK
 
+## Using SDK from Source
+
+Using SDK from source requires running `npm run dist` to create a `dist/` subdirectory
+which produces the structure used for the npm package.
+
+```
+# Clone the repository
+git clone https://github.com/boundlessgeo/sdk.git
+# Enter the repo
+cd sdk
+# install dependencies
+npm install
+# create the package
+npm run dist
+# enter the package directory
+cd dist/
+# link to SDK
+npm link
+```
+
 ## Testing and the canvas module
 
 The test suite uses the NPM `canvas` module to test certain interactions

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ and run the following commands:
 
 The last command should open your browser to a page of examples: http://localhost:3000/build/examples
 
+## Using the SDK source to develop a local project
+
+Please read [DEVELOPING.md](DEVELOPING.md) on how to create the SDK package and link to it locally.
+
 ## Troubleshooting
 
 If `npm start` fails review node version, SDK targets v6.0 or greater.  On OSX node install can be error prone, seems to work best when installed by Brew http://brewformulas.org/Node


### PR DESCRIPTION
SDK needs to have the package "built" to properly work with
a project. This documents the steps to creating the package
and then linking to it for local use.