### PR TITLE
Added fontawesome/font-icon example

### DIFF
--- a/examples/feature-table/app.js
+++ b/examples/feature-table/app.js
@@ -68,7 +68,6 @@ function main() {
       'text-field': '\uf072',
     },
     paint: {
-      //'text-color': '#552211',
       'text-color': '#CF5300',
     },
   }));

--- a/examples/feature-table/app.js
+++ b/examples/feature-table/app.js
@@ -61,7 +61,7 @@ function main() {
     type: 'symbol',
     source: 'dynamic-source',
     layout: {
-      'text-font': 'FontAwesome Regular',
+      'text-font': ['FontAwesome normal',],
       'text-size': 18,
       'icon-optional': true,
       // airplane icon

--- a/examples/feature-table/app.js
+++ b/examples/feature-table/app.js
@@ -58,12 +58,18 @@ function main() {
 
   store.dispatch(mapActions.addLayer({
     id: 'dynamic-layer',
-    type: 'circle',
+    type: 'symbol',
     source: 'dynamic-source',
+    layout: {
+      'text-font': 'FontAwesome Regular',
+      'text-size': 18,
+      'icon-optional': true,
+      // airplane icon
+      'text-field': '\uf072',
+    },
     paint: {
-      'circle-radius': 5,
-      'circle-color': '#552211',
-      'circle-stroke-color': '#00ff11',
+      //'text-color': '#552211',
+      'text-color': '#CF5300',
     },
   }));
 

--- a/examples/feature-table/index.html
+++ b/examples/feature-table/index.html
@@ -7,7 +7,8 @@ docs: >
   <li>Adding a GeoJSON-type layer to a map using Fetch</li>
   <li>Displaying data in a simple table</li>
   <li>Using Font Awesome to create map icons.</li>
+resources:
+  - https://use.fontawesome.com/2f2c3f1eb2.js
 ---
-<script src="https://use.fontawesome.com/2f2c3f1eb2.js"></script>
 <div id="controls"></div>
 <div id="table"></div>

--- a/examples/feature-table/index.html
+++ b/examples/feature-table/index.html
@@ -6,6 +6,8 @@ docs: >
   <li>Adding an tiled map</li>
   <li>Adding a GeoJSON-type layer to a map using Fetch</li>
   <li>Displaying data in a simple table</li>
+  <li>Using Font Awesome to create map icons.</li>
 ---
+<script src="https://use.fontawesome.com/2f2c3f1eb2.js"></script>
 <div id="controls"></div>
 <div id="table"></div>


### PR DESCRIPTION
Uses the font-awesome icons to represent the
airports as little airplanes on the map.

It's both cute AND demonstrates using a font as an icon
alternative to a "circle" type layer.