### PR TITLE
Fix for popup autoPan

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -895,6 +895,7 @@ export class Map extends React.Component {
     overlays.forEach((overlay) => {
       const id = overlay.get('popupId');
       if (this.popups[id].state.closed !== false) {
+        this.popups[id].setMap(null);
         // mark this for removal
         overlays_to_remove.push(overlay);
         // umount the component from the DOM
@@ -928,7 +929,7 @@ export class Map extends React.Component {
     const id = uuid.v4();
 
     const elem = document.createElement('div');
-
+    elem.setAttribute("class", "sdk-popup");
     const overlay = new Overlay({
       // create an empty div element for the Popup
       element: elem,
@@ -954,6 +955,7 @@ export class Map extends React.Component {
     ReactDOM.render(popup, elem, (function addInstance() {
       self.popups[id] = this;
       self.elems[id] = elem;
+      this.setMap(self);
     }));
 
     // set the popup id so we can match the component

--- a/src/components/map/popup.js
+++ b/src/components/map/popup.js
@@ -29,7 +29,16 @@ class Popup extends React.PureComponent {
 
   close() {
     this.setState({ closed: true });
+    this.setState({ closed: true }, () => {
+      if (this.map) {
+        this.map.updatePopups();
+      }
+    });
     this.props.onClose();
+  }
+
+  setMap(map) {
+    this.map = map;
   }
 
   renderPopup(children) {
@@ -40,7 +49,7 @@ class Popup extends React.PureComponent {
     if (this.state.closed) {
       return false;
     }
-    let className = 'sdk-popup';
+    let className = 'sdk-popup-root';
     if (this.props.className) {
       className = `${className} ${this.props.className}`;
     }


### PR DESCRIPTION
Since #662 popup autoPan was broken. This PR adds a different solution than the DOM manipulation we did back then.

I'm not 100% happy with having to pass a reference to the map to the popup, but I couldn't think of a better approach.

@CarlyLanglois would be great if you can confirm that this fixes things for you.
@theduckylittle would like to have your feedback on this one