### PR TITLE
Have a generic controls prop instead of showZoomSlider

### DIFF
--- a/__tests__/components/map.test.js
+++ b/__tests__/components/map.test.js
@@ -16,6 +16,7 @@ import TileJSONSource from 'ol/source/tilejson';
 import TileWMSSource from 'ol/source/tilewms';
 import ImageTile from 'ol/imagetile';
 import TileState from 'ol/tilestate';
+import ZoomSlider from 'ol/control/zoomslider';
 
 import { createStore, combineReducers } from 'redux';
 import { radiansToDegrees } from '../../src/util';
@@ -725,11 +726,11 @@ describe('Map component', () => {
     }));
     mount(<ConnectedMap store={store} />);
   });
-  it('should add the zoomSlider using showZoomSlider prop', () => {
+  it('should add the zoomSlider using controls prop', () => {
     const store = createStore(combineReducers({
       map: MapReducer,
     }));
-    const wrapper = mount(<ConnectedMap store={store} showZoomSlider />);
+    const wrapper = mount(<ConnectedMap store={store} controls={[new ZoomSlider()]} />);
     expect(wrapper.html().indexOf('ol-zoomslider')).toBeGreaterThan(0);
   });
 
@@ -737,7 +738,7 @@ describe('Map component', () => {
     const store = createStore(combineReducers({
       map: MapReducer,
     }));
-    const wrapper = mount(<ConnectedMap store={store} showZoomSlider={false} />);
+    const wrapper = mount(<ConnectedMap store={store} />);
     expect(wrapper.html().indexOf('ol-zoomslider')).toBe(-1);
   });
 

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -16,6 +16,8 @@ import SdkHashHistory from '@boundlessgeo/sdk/components/history';
 import SdkMapReducer from '@boundlessgeo/sdk/reducers/map';
 import * as mapActions from '@boundlessgeo/sdk/actions/map';
 
+import ZoomSlider from 'ol/control/zoomslider';
+
 // This will have webpack include all of the SDK styles.
 import '@boundlessgeo/sdk/stylesheet/sdk.scss';
 
@@ -183,7 +185,7 @@ function main() {
   };
 
   // place the map on the page.
-  ReactDOM.render(<SdkMap store={store} showZoomSlider />, document.getElementById('map'));
+  ReactDOM.render(<SdkMap store={store} controls={[new ZoomSlider()]} />, document.getElementById('map'));
 
   // add some buttons to demo some actions.
   ReactDOM.render((

--- a/examples/filter/app.js
+++ b/examples/filter/app.js
@@ -12,6 +12,8 @@ import SdkMap from '@boundlessgeo/sdk/components/map';
 import SdkMapReducer from '@boundlessgeo/sdk/reducers/map';
 import * as mapActions from '@boundlessgeo/sdk/actions/map';
 
+import ZoomSlider from 'ol/control/zoomslider';
+
 import FilterComponent from './filter';
 
 // This will have webpack include all of the SDK styles.
@@ -70,7 +72,7 @@ function main() {
   };
   loadJson();
   // place the map on the page.
-  ReactDOM.render(<SdkMap store={store} showZoomSlider />, document.getElementById('map'));
+  ReactDOM.render(<SdkMap store={store} controls={[new ZoomSlider()]} />, document.getElementById('map'));
 
   // add some buttons to demo some actions.
   ReactDOM.render((

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -37,7 +37,6 @@ import XyzSource from 'ol/source/xyz';
 import TileWMSSource from 'ol/source/tilewms';
 import TileJSON from 'ol/source/tilejson';
 import TileGrid from 'ol/tilegrid';
-import ZoomControl from 'ol/control/zoomslider';
 
 import VectorTileLayer from 'ol/layer/vectortile';
 import VectorTileSource from 'ol/source/vectortile';
@@ -1090,9 +1089,12 @@ export class Map extends React.Component {
       }),
     });
 
-    if (this.props.showZoomSlider) {
-      this.map.addControl(new ZoomControl());
+    if (this.props.controls) {
+      for (let i = 0, ii = this.props.controls.length; i < ii; ++i) {
+        this.map.addControl(this.props.controls[i]);
+      }
     }
+
     // when the map moves update the location in the state
     this.map.on('moveend', () => {
       this.props.setView(this.map.getView());
@@ -1284,7 +1286,7 @@ Map.propTypes = {
     interaction: PropTypes.string,
     sourceName: PropTypes.string,
   }),
-  showZoomSlider: PropTypes.bool,
+  controls: PropTypes.array,
   initialPopups: PropTypes.arrayOf(PropTypes.object),
   setView: PropTypes.func,
   includeFeaturesOnClick: PropTypes.bool,
@@ -1317,7 +1319,6 @@ Map.defaultProps = {
     interaction: null,
     source: null,
   },
-  showZoomSlider: false,
   initialPopups: [],
   setView: () => {
     // swallow event.


### PR DESCRIPTION
Instead of having specific props for controls, we can have a generic one.

We can leave creation of the controls up to the application, so we don't have a lot of potentially unused code in SDK core.