### PR TITLE
Use correct propType for children in Map

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -1281,7 +1281,10 @@ Map.propTypes = {
     sources: PropTypes.object,
     sprite: PropTypes.string,
   }),
-  children: PropTypes.array,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
   style: PropTypes.object,
   className: PropTypes.string,
   drawing: PropTypes.shape({


### PR DESCRIPTION
the children proptype can be a node or an array of nodes