### PR TITLE
Instructions on Ejecting Create-React-App

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -58,5 +58,8 @@ of tests will be skipped.
 6. Serving content.
 
     After the watch task has been setup the `build/` directory will need to be
-    served using a HTTP server.
- 
+    served using a HTTP server. The create-react-app documentation recommends using
+    `serve` but this can be problematic as `serve` does not support proxying.
+
+    As an alternative, [http-server](https://github.com/indexzero/http-server) does support
+    proxying and is also a light weight install.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -33,3 +33,30 @@ sudo apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev g+
 
 It is possible to run the tests without the `canvas` module. In this case a number
 of tests will be skipped.
+
+
+## Ejecting Create React App
+
+
+1. `yarn eject`
+2. `yarn add webpack-cli`
+3. Modify `config/webpack.config.prod.js`, change 149 from:
+    ```
+    include: paths.appSrc,
+    ```
+    To:
+    ```
+    include: [paths.appSrc, '../node_modules'],
+    ```
+4. Modify `config/webpack.config.dev.js`, comment out line 46,
+   hot reloading will not work inside of a served environment.
+
+5. Modify `package.json` by ading the following line after `"scripts": {`:
+    ```
+    "watch": "NODE_ENV=development webpack --watch --config ./config/webpack.config.dev.js",
+    ```
+6. Serving content.
+
+    After the watch task has been setup the `build/` directory will need to be
+    served using a HTTP server.
+ 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -35,31 +35,3 @@ It is possible to run the tests without the `canvas` module. In this case a numb
 of tests will be skipped.
 
 
-## Ejecting Create React App
-
-
-1. `yarn eject`
-2. `yarn add webpack-cli`
-3. Modify `config/webpack.config.prod.js`, change 149 from:
-    ```
-    include: paths.appSrc,
-    ```
-    To:
-    ```
-    include: [paths.appSrc, '../node_modules'],
-    ```
-4. Modify `config/webpack.config.dev.js`, comment out line 46,
-   hot reloading will not work inside of a served environment.
-
-5. Modify `package.json` by ading the following line after `"scripts": {`:
-    ```
-    "watch": "NODE_ENV=development webpack --watch --config ./config/webpack.config.dev.js",
-    ```
-6. Serving content.
-
-    After the watch task has been setup the `build/` directory will need to be
-    served using a HTTP server. The create-react-app documentation recommends using
-    `serve` but this can be problematic as `serve` does not support proxying.
-
-    As an alternative, [http-server](https://github.com/indexzero/http-server) does support
-    proxying and is also a light weight install.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -229,7 +229,7 @@ Congratulations! You should have a fully operational Boundless SDK React app!
 
    ```
 
-5. Modify `package.json` by ading the following line after `"scripts": {`:
+5. Modify `package.json` by adding the following line after `"scripts": {`:
     ```
     "watch": "NODE_ENV=development webpack --watch --config ./config/webpack.config.dev.js",
     ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -183,3 +183,32 @@ yarn start
 ## Fin!
 
 Congratulations! You should have a fully operational Boundless SDK React app!
+
+
+### Ejecting Create React App
+
+1. `yarn eject`
+2. `yarn add webpack-cli`
+3. Modify `config/webpack.config.prod.js`, change 149 from:
+    ```
+    include: paths.appSrc,
+    ```
+    To:
+    ```
+    include: [paths.appSrc, '../node_modules'],
+    ```
+4. Modify `config/webpack.config.dev.js`, comment out line 46,
+   hot reloading will not work inside of a served environment.
+
+5. Modify `package.json` by ading the following line after `"scripts": {`:
+    ```
+    "watch": "NODE_ENV=development webpack --watch --config ./config/webpack.config.dev.js",
+    ```
+6. Serving content.
+
+    After the watch task has been setup the `build/` directory will need to be
+    served using a HTTP server. The create-react-app documentation recommends using
+    `serve` but this can be problematic as `serve` does not support proxying.
+
+    As an alternative, [http-server](https://github.com/indexzero/http-server) does support
+    proxying and is also a light weight install.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -189,16 +189,45 @@ Congratulations! You should have a fully operational Boundless SDK React app!
 
 1. `yarn eject`
 2. `yarn add webpack-cli`
-3. Modify `config/webpack.config.prod.js`, change 149 from:
+3. Modify `config/webpack.config.prod.js`.
+
+    This section defines which files Babel will transform (on or about line 149):
+    ```javascript
+      // Process JS with Babel.
+      {
+        test: /\.(js|jsx)$/,
+        include: paths.appSrc,
+        loader: require.resolve('babel-loader'),
+        options: {
+
+          compact: true,
+        },
+      },
+    ```
+
+    The include path must be changed from: 
     ```
     include: paths.appSrc,
     ```
     To:
     ```
-    include: [paths.appSrc, '../node_modules'],
+    include: [paths.appSrc, path.resolve(__dirname, '../node_modules/')],
     ```
-4. Modify `config/webpack.config.dev.js`, comment out line 46,
-   hot reloading will not work inside of a served environment.
+4. Modify `config/webpack.config.dev.js`, to disable hot-reloading.
+   Hot reloading will not work inside of webpack-dev-server and will simply
+   throw additional errors when served from a static webserver.
+
+   Change this line (on or about line 46):
+
+   ```
+    require.resolve('react-dev-utils/webpackHotDevClient'),
+   ```
+
+   To:
+   ```
+    // require.resolve('react-dev-utils/webpackHotDevClient'),
+
+   ```
 
 5. Modify `package.json` by ading the following line after `"scripts": {`:
     ```


### PR DESCRIPTION
create-react-app will not be able to _build_ a bundle due to some issues with various SDK dependencies. These instructions provide detail on what to do next.