### PR TITLE
Vector legend fixes

### DIFF
--- a/__tests__/components/__snapshots__/legend.test.js.snap
+++ b/__tests__/components/__snapshots__/legend.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`test the Legend component should allow for custom className 1`] = `"<div class=\\"sdk-legend foo\\"></div>"`;
 
-exports[`test the Legend component should allow for custom size 1`] = `"<div class=\\"sdk-legend\\"><canvas></canvas></div>"`;
+exports[`test the Legend component should allow for custom size 1`] = `"<div class=\\"sdk-legend\\"><canvas width=\\"100\\" height=\\"100\\" style=\\"width: 100px; height: 100px;\\"></canvas></div>"`;
 
 exports[`test the Legend component should allow for vector (line) legend 1`] = `"<div class=\\"sdk-legend\\"><canvas width=\\"50\\" height=\\"50\\" style=\\"width: 50px; height: 50px;\\"></canvas></div>"`;
 

--- a/src/components/legend.js
+++ b/src/components/legend.js
@@ -92,8 +92,6 @@ export function getLegend(layer) {
   }
 }
 
-const olLayer = new VectorLayer();
-
 const pointGeomCache = {};
 export function getPointGeometry(size) {
   if (!pointGeomCache[size]) {
@@ -153,7 +151,7 @@ export function getVectorLegend(layer, layer_src, props) {
           props.mapbox.baseUrl,
           props.mapbox.accessToken
         );
-
+        const olLayer = new VectorLayer();
         applyStyle(olLayer, fake_style, layer.source).then(function() {
           const styleFn = olLayer.getStyle();
           let geom;

--- a/src/components/legend.js
+++ b/src/components/legend.js
@@ -172,9 +172,11 @@ export function getVectorLegend(layer, layer_src, props) {
             const feature = new Feature(properties);
             feature.setGeometry(geom);
             const styles = styleFn(feature);
-            for (let i = 0, ii = styles.length; i < ii; ++i) {
-              vectorContext.setStyle(styles[i]);
-              vectorContext.drawGeometry(geom);
+            if (styles) {
+              for (let i = 0, ii = styles.length; i < ii; ++i) {
+                vectorContext.setStyle(styles[i]);
+                vectorContext.drawGeometry(geom);
+              }
             }
           }
         });

--- a/src/components/legend.js
+++ b/src/components/legend.js
@@ -92,8 +92,6 @@ export function getLegend(layer) {
   }
 }
 
-const vectorCache = {};
-const canvasCache = {};
 const olLayer = new VectorLayer();
 
 const pointGeomCache = {};
@@ -141,16 +139,7 @@ export function getVectorLegend(layer, layer_src, props) {
     const size = props.size;
     return (<canvas ref={(c) => {
       if (c !== null) {
-        let vectorContext;
-        if (!vectorCache[layer.id]) {
-          canvasCache[layer.id] = c;
-          vectorContext = OlRender.toContext(c.getContext('2d'), {size: size});
-          vectorCache[layer.id] = vectorContext;
-        } else {
-          vectorContext = vectorCache[layer.id];
-          const canvas = canvasCache[layer.id];
-          canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
-        }
+        let vectorContext = OlRender.toContext(c.getContext('2d'), {size: size});
         let newLayer;
         if (layer.filter) {
           newLayer = jsonClone(layer);
@@ -183,8 +172,8 @@ export function getVectorLegend(layer, layer_src, props) {
             const feature = new Feature(properties);
             feature.setGeometry(geom);
             const styles = styleFn(feature);
-            if (styles && styles.length > 0) {
-              vectorContext.setStyle(styles[0]);
+            for (let i = 0, ii = styles.length; i < ii; ++i) {
+              vectorContext.setStyle(styles[i]);
               vectorContext.drawGeometry(geom);
             }
           }


### PR DESCRIPTION
SDK-738

This PR fixes multiple issues with vector legends:

- legends will get overwritten
- legends did not use strokes
- legends from multiple layers were being the same as the last layer