### PR TITLE
Prevent deprecation message in dist-copy task

### DIFF
--- a/tasks/dist-copy.js
+++ b/tasks/dist-copy.js
@@ -36,7 +36,14 @@ function main() {
 
   // build the new README
   // this is more appropriate for an NPM readme...
-  fs.writeFile(path.join(distDir, 'README.md'), README_HEADER + QUICKSTART);
+  fs.writeFile(path.join(distDir, 'README.md'), README_HEADER + QUICKSTART, function(err) {
+    if(err) {
+      // eslint-disable-next-line no-console
+      return console.log(err);
+    }
+    // eslint-disable-next-line no-console
+    console.log("README.md written correctly.");
+  });
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Our dist-copy task was showing a deprecation message, this PR fixes this:

```
(node:5531) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
Created package.json in /home/bartvde/opengeo/git/sdk_bartvde/dist/package.json
```