### PR TITLE
Use different devtool to prevent CORS warning

### DIFF
--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -27,7 +27,7 @@ const config = {
       }
     },
   },
-  devtool: 'eval',
+  devtool: 'cheap-module-source-map',
   node: {fs: "empty"},
   output: {
     path: __dirname, // Path of output file


### PR DESCRIPTION
This came up in SDK-666

It's to fix https://reactjs.org/docs/cross-origin-errors.html