### PR TITLE
Add note to upgrade notes for changed import

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,4 +1,16 @@
 ## Upgrade notes
 
 ### Next Release
+
+#### ol package
 The version of the ```ol``` package was updated to 4.4.2.
+
+#### Custom layer list items
+If you were using a custom layer list item for the layer list, the imports for the base class were moved from:
+```
+import { SdkLayerListItem } from '@boundlessgeo/sdk/components/layer-list';
+```
+to:
+```
+import SdkLayerListItem from '@boundlessgeo/sdk/components/layer-list-item';
+```


### PR DESCRIPTION
This is a follow-up from #721 forgot to add a note to the upgrade notes that the import for layer list item has changed