### PR TITLE
Removed id="map" from template wrapper

### DIFF
--- a/config/templates/example.html
+++ b/config/templates/example.html
@@ -12,7 +12,6 @@
     {{> header }}
     <div class="contentContainer">
       <h1>{{ shortdesc }}</h1>
-      <div id="map"></div>
       <div class="description">
         {{{ contents }}}
         <div class="info">


### PR DESCRIPTION
This div id is dupe'd in the DOM by most of the examples.