### PR TITLE
Made "bnd:queryable" a constant.

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -69,7 +69,7 @@ import AttributionControl from 'ol/control/attribution';
 import LoadingStrategy from 'ol/loadingstrategy';
 
 import {updateLayer, setView, setRotation} from '../actions/map';
-import {INTERACTIONS, LAYER_VERSION_KEY, SOURCE_VERSION_KEY, TIME_KEY, TIME_ATTRIBUTE_KEY} from '../constants';
+import {INTERACTIONS, LAYER_VERSION_KEY, SOURCE_VERSION_KEY, TIME_KEY, TIME_ATTRIBUTE_KEY, QUERYABLE_KEY} from '../constants';
 import {dataVersionKey} from '../reducers/map';
 
 import {setMeasureFeature, clearMeasureFeature} from '../actions/drawing';
@@ -1088,7 +1088,7 @@ export class Map extends React.Component {
   handleWMSGetFeatureInfo(layer, promises, evt) {
     const map_prj = this.map.getView().getProjection();
     const map_resolution = this.map.getView().getResolution();
-    if (layer.metadata['bnd:queryable'] && (!layer.layout || (layer.layout.visibility && layer.layout.visibility !== 'none'))) {
+    if (layer.metadata[QUERYABLE_KEY] && (!layer.layout || (layer.layout.visibility && layer.layout.visibility !== 'none'))) {
       const source = this.sources[layer.source];
       if (source instanceof TileWMSSource) {
         promises.push(new Promise((resolve) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,6 +25,7 @@ export const DATA_VERSION_KEY = 'bnd:data-version';
 export const GROUPS_KEY = 'mapbox:groups';
 export const GROUP_KEY = 'mapbox:group';
 export const LAYERLIST_HIDE_KEY = 'bnd:hide-layerlist';
+export const QUERYABLE_KEY = 'bnd:queryable';
 
 export const DEFAULT_ZOOM = {
   MIN: 0,


### PR DESCRIPTION
Before the queryable boolean metadata needed to by typed out manually each time.