### PR TITLE
added getLayerSource

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -229,11 +229,11 @@ export function getLayerTitle(layer) {
 export function getLayerSource(layer, sources) {
   const sourceKeys = Object.keys(sources);
 
-  for(let i=0; i<sourceKeys.length;i++) {
-    if(sourceKeys[i] === layer.source){
+  for (let i = 0; i < sourceKeys.length; i++) {
+    if (sourceKeys[i] === layer.source) {
       return sources[sourceKeys[i]];
     } else {
       return null;
     }
   }
-};
+}

--- a/src/util.js
+++ b/src/util.js
@@ -218,3 +218,22 @@ export function getLayerTitle(layer) {
   }
   return layer.id;
 }
+
+/** Get the source of a layer.
+ *
+ *  @param {Object} layer The layer.
+ *  @param {Object} sources The map sources.
+ *
+ * @returns {Object} The source object of the layer.
+ */
+export function getLayerSource(layer, sources) {
+  const sourceKeys = Object.keys(sources);
+
+  for(let i=0; i<sourceKeys.length;i++) {
+    if(sourceKeys[i] === layer.source){
+      return sources[sourceKeys[i]];
+    } else {
+      return null;
+    }
+  }
+};


### PR DESCRIPTION
Added getLayerSource - a utility function for getting the source object of a map layer.  It's a common operation that's needed to get the underlying data in order to pass to other tools (e.g., turf).