### PR TITLE
Add additional helpers for configuring sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "@mapbox/mapbox-gl-style-spec": "^9.0.0",
     "isomorphic-fetch": "^2.2.1",
+    "jest-cli": "^21.2.1",
     "ol-mapbox-style": "^2.6.1",
     "prop-types": "^15.5.10",
     "react-dnd": "^2.5.4",


### PR DESCRIPTION
1. Small change to package.json to include the jest-cli.
   I believe in older version of Jest this is included but I was
   getting an error that tests could not be run without expressly
   including the cli package.
2. New actions which short-hand the creation of complex source
   definitions.