### PR TITLE
Make sure we set circle-stroke-width

### DIFF
--- a/examples/paint-change/app.js
+++ b/examples/paint-change/app.js
@@ -77,6 +77,7 @@ function main() {
       'circle-radius': 5,
       'circle-color': '#756bb1',
       'circle-stroke-color': '#756bb1',
+      'circle-stroke-width': 1,
     },
   }));
 
@@ -120,6 +121,7 @@ function main() {
       'circle-radius': radius,
       'circle-color': type === 'fill' ? color : fill,
       'circle-stroke-color': type === 'stroke' ? color : stroke,
+      'circle-stroke-width': 1,
     };
     store.dispatch(mapActions.updateLayer('random-points', {
       paint,
@@ -178,6 +180,7 @@ function main() {
       'circle-radius': size,
       'circle-color': fill,
       'circle-stroke-color': stroke,
+      'circle-stroke-width': 1,
     };
     store.dispatch(mapActions.updateLayer('random-points', {
       paint,


### PR DESCRIPTION
The stroke of the circle in paint-change example was never visible, this is because the default value of circle-stroke-width is 0

Before this was not enforced in mapbox-to-ol-style so we did not notice it