### PR TITLE
Added getLayersByGroup func, exposed more dnd API.

### DIFF
--- a/__tests__/root/util.test.js
+++ b/__tests__/root/util.test.js
@@ -182,17 +182,35 @@ describe('util', () => {
     expect(util.reprojectGeoJson(geoJson3857, 'EPSG:4326')).toEqual(features4326);
   });
 
-  it('tests find a layer in a list by id', () => {
-    const layers = [{
+  function getSampleLayers() {
+    return [{
       id: 'A',
+      metadata: {
+        'mapbox:group': 'grp',
+      },
     }, {
       id: 'B',
+      metadata: {
+        'mapbox:group': 'grp',
+      },
     }, {
       id: 'C',
     }];
+  }
+
+  it('tests find a layer in a list by id', () => {
+    const layers = getSampleLayers();
 
     expect(util.getLayerIndexById(layers, 'A')).toBe(0);
 
     expect(util.getLayerIndexById(layers, 'D')).toBe(-1);
+  });
+
+  it('gets a set of layers by group id', () => {
+    const layers = getSampleLayers();
+    const matches = util.getLayersByGroup(layers, 'grp');
+
+    // check to see the first two layers were found.
+    expect(matches).toEqual(layers.slice(0, 2));
   });
 });

--- a/src/components/layer-list-item.js
+++ b/src/components/layer-list-item.js
@@ -46,11 +46,13 @@ export const layerListItemTarget = {
 export function collect(connect, monitor) {
   return {
     connectDragSource: connect.dragSource(),
+    connectDragPreview: connect.dragPreview(),
   };
 }
 
 export function collectDrop(connect, monitor) {
   return {
+    isOver: monitor.isOver({shallow: true}),
     connectDropTarget: connect.dropTarget()
   };
 }

--- a/src/util.js
+++ b/src/util.js
@@ -218,3 +218,20 @@ export function getLayerTitle(layer) {
   }
   return layer.id;
 }
+
+/** Get a list of layers based on the group
+ *
+ *  @param {Array} layers The list of layers.
+ *  @param {string} groupId the group ID
+ *
+ * @return {Array} of matching layers.
+ */
+export function getLayersByGroup(layers, groupId) {
+  const group_layers = [];
+  for (let i = 0, ii = layers.length; i < ii; i++) {
+    if (getGroup(layers[i]) === groupId) {
+      group_layers.push(layers[i]);
+    }
+  }
+  return group_layers;
+}


### PR DESCRIPTION
1. Needed to expose the isOver and DragPrevew API's of
   react-dnd to improve catalog interactions.
2. Added a getLayersByGroup function which is useful for
   collecting a set of style layers to be saved in GeoServer.