### PR TITLE
Fixes to be more in line with Mapbox GL JS / style spec

### DIFF
--- a/__tests__/reducers/map.test.js
+++ b/__tests__/reducers/map.test.js
@@ -61,7 +61,6 @@ describe('map reducer', () => {
           metadata: {
             'bnd:title': title,
           },
-          filter: null,
         },
       ],
     });

--- a/examples/basic-wgs84/app.js
+++ b/examples/basic-wgs84/app.js
@@ -52,6 +52,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'esri',
     source: 'esri',
+    type: 'raster',
   }));
 
   // 'geojson' sources allow rendering a vector layer
@@ -101,6 +102,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'random-points',
     source: 'points',
+    type: 'circle',
     paint: {
       'circle-radius': 5,
       'circle-color': '#756bb1',

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -52,6 +52,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // 'geojson' sources allow rendering a vector layer
@@ -101,6 +102,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'random-points',
     source: 'points',
+    type: 'circle',
     paint: {
       'circle-radius': 5,
       'circle-color': '#756bb1',

--- a/examples/bookmark/app.js
+++ b/examples/bookmark/app.js
@@ -58,6 +58,7 @@ function main() {
         }));
         store.dispatch(mapActions.addLayer({
           id: sourceName,
+          type: 'circle',
           source: sourceName,
           paint: {
             'circle-radius': 5,

--- a/examples/clustering/app.js
+++ b/examples/clustering/app.js
@@ -47,6 +47,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // 'geojson' sources allow rendering a vector layer
@@ -87,9 +88,10 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'clustered-labels',
     source: 'points',
+    type: 'symbol',
     layout: {
       'text-field': '{point_count}',
-      'text-font': ['Arial'],
+      'text-font': ['Open Sans Regular'],
       'text-size': 10,
     },
     filter: ['has', 'point_count'],

--- a/examples/drawing/app.js
+++ b/examples/drawing/app.js
@@ -53,6 +53,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // Add three individual GeoJSON stores for the

--- a/examples/export-image/app.js
+++ b/examples/export-image/app.js
@@ -29,7 +29,7 @@ const store = createStore(combineReducers({
 applyMiddleware(thunkMiddleware));
 
 function main() {
-  const url = 'https://raw.githubusercontent.com/boundlessgeo/ol-mapbox-style/master/example/data/wms.json';
+  const url = 'wms.json';
   store.dispatch(mapActions.setContext({url}));
 
   const exportMapImage = (blob) => {

--- a/examples/export-image/wms.json
+++ b/examples/export-image/wms.json
@@ -1,8 +1,8 @@
 {
   "version": 8,
-  "name": "bookmarks",
-  "center":[2.336734,48.885318],
-  "zoom": 18,
+  "name": "states-wms",
+  "center": [-98.78906130124426, 37.92686191312036],
+  "zoom": 4,
   "sources": {
     "osm": {
       "type": "raster",
@@ -13,6 +13,11 @@
         "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
         "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
       ]
+    },
+    "states": {
+      "type": "raster",
+      "tileSize": 256,
+      "tiles": ["https://demo.boundlessgeo.com/geoserver/usa/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image/png&SRS=EPSG:900913&LAYERS=topp:states&STYLES=&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}"]
     }
   },
   "layers": [
@@ -25,9 +30,13 @@
     },
     {
       "id": "osm",
-      "type": "raster",
-      "source": "osm"
+      "source": "osm",
+      "type": "raster"
+    },
+    {
+      "id": "states-wms",
+      "source": "states",
+      "type": "raster"
     }
-  ],
-  "bearing": 0
+  ]
 }

--- a/examples/feature-table/app.js
+++ b/examples/feature-table/app.js
@@ -55,6 +55,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // 'geojson' sources allow rendering a vector layer

--- a/examples/filter/app.js
+++ b/examples/filter/app.js
@@ -48,6 +48,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
 

--- a/examples/geolocation/app.js
+++ b/examples/geolocation/app.js
@@ -49,6 +49,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // Background layers change the background color of

--- a/examples/layer-list/app.js
+++ b/examples/layer-list/app.js
@@ -99,6 +99,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
     metadata: {
       'mapbox:group': 'base'
     }
@@ -120,6 +121,7 @@ function main() {
       'mapbox:group': 'base',
       'bnd:title': 'CartoDB light',
     },
+    type: 'raster',
     layout: {
       visibility: 'none',
     },
@@ -209,6 +211,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'states',
     source: 'states',
+    type: 'raster',
   }));
 
   // place the map on the page.

--- a/examples/legends/app.js
+++ b/examples/legends/app.js
@@ -48,6 +48,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
     metadata: {
       'bnd:legend-type': 'href',
       'bnd:legend-content': './osm-legend.html',
@@ -89,6 +90,7 @@ function main() {
   // some purple points!
   store.dispatch(mapActions.addLayer({
     id: 'random-points',
+    type: 'circle',
     source: 'points',
     paint: {
       'circle-radius': 5,
@@ -123,11 +125,12 @@ function main() {
   store.dispatch(mapActions.addSource('states', {
     type: 'raster',
     tileSize: 256,
-    tiles: ['https://ahocevar.com/geoserver/gwc/service/wms?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image/png&SRS=EPSG:900913&LAYERS=topp:states&STYLES=&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}'],
+    tiles: ['https://demo.boundlessgeo.com/geoserver/wms?SERVICE=WMS&VERSION=1.1.1&TILED=TRUE&REQUEST=GetMap&FORMAT=image/png&SRS=EPSG:900913&LAYERS=topp:states&STYLES=&WIDTH=256&HEIGHT=256&BBOX={bbox-epsg-3857}'],
   }));
 
   store.dispatch(mapActions.addLayer({
     id: 'states',
+    type: 'raster',
     source: 'states',
   }));
 

--- a/examples/paint-change/app.js
+++ b/examples/paint-change/app.js
@@ -45,6 +45,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // 'geojson' sources allow rendering a vector layer

--- a/examples/popups/app.js
+++ b/examples/popups/app.js
@@ -141,6 +141,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // Add a geojson source to the map.

--- a/examples/realtime/app.js
+++ b/examples/realtime/app.js
@@ -53,6 +53,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   const url = 'https://wanderdrone.appspot.com/';

--- a/examples/rotating/app.js
+++ b/examples/rotating/app.js
@@ -43,6 +43,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // Background layers change the background color of

--- a/examples/sprite-animation/app.js
+++ b/examples/sprite-animation/app.js
@@ -46,6 +46,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // 'geojson' sources allow rendering a vector layer

--- a/examples/sprites/app.js
+++ b/examples/sprites/app.js
@@ -46,6 +46,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // 'geojson' sources allow rendering a vector layer

--- a/examples/wfst/app.js
+++ b/examples/wfst/app.js
@@ -90,6 +90,7 @@ function main() {
   store.dispatch(SdkMapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   const colors = ['#fef0d9', '#fdcc8a', '#fc8d59', '#e34a33', '#b30000'];

--- a/examples/wms/app.js
+++ b/examples/wms/app.js
@@ -46,6 +46,7 @@ function main() {
   store.dispatch(mapActions.addLayer({
     id: 'osm',
     source: 'osm',
+    type: 'raster',
   }));
 
   // set the background color.
@@ -78,6 +79,7 @@ function main() {
               tiles: [getMapUrl],
             }));
             store.dispatch(mapActions.addLayer({
+              type: 'raster',
               metadata: {
                 'bnd:title': layer.Title,
                 'bnd:queryable': layer.queryable,

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -265,7 +265,6 @@ function addLayer(state, action) {
   // TODO: Maybe decide on what a "default case" is in
   //       order to support easier dev.
   const new_layer = Object.assign({
-    filter: null,
     paint: {},
     metadata: {},
   }, action.layerDef);


### PR DESCRIPTION
- layers need to have a type or ref (SDK-722)
- filter cannot be null (SDK-774)

Also fixes SDK-776 (overlay not visible in export image example)