### PR TITLE
Only use background layer in examples for which it makes sense

### DIFF
--- a/examples/basic-wgs84/app.js
+++ b/examples/basic-wgs84/app.js
@@ -72,16 +72,6 @@ function main() {
     },
   }));
 
-  // Background layers change the background color of
-  // the map. They are not attached to a source.
-  store.dispatch(mapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
-
   // Show null island as a layer.
   store.dispatch(mapActions.addLayer({
     id: 'null-island',

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -72,16 +72,6 @@ function main() {
     },
   }));
 
-  // Background layers change the background color of
-  // the map. They are not attached to a source.
-  store.dispatch(mapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
-
   // Show null island as a layer.
   store.dispatch(mapActions.addLayer({
     id: 'null-island',

--- a/examples/feature-table/app.js
+++ b/examples/feature-table/app.js
@@ -63,16 +63,6 @@ function main() {
   // be an individual Feature or a FeatureCollection.
   store.dispatch(mapActions.addSource('dynamic-source', {type: 'geojson'}));
 
-  // Background layers change the background color of
-  // the map. They are not attached to a source.
-  store.dispatch(mapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
-
   // Fetch the geoJson file from a url and add it to the map at the named source
   const addLayerFromGeoJSON = (url, sourceName) => {
     store.dispatch(mapActions.addLayer({

--- a/examples/filter/app.js
+++ b/examples/filter/app.js
@@ -51,16 +51,6 @@ function main() {
     type: 'raster',
   }));
 
-
-  // Background layers change the background color of
-  // the map. They are not attached to a source.
-  store.dispatch(mapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
   const loadJson = (sourceName) => {
     store.dispatch(mapActions.addSource('states', {type: 'geojson', data: 'states.geojson'}));
     store.dispatch(mapActions.addLayer({

--- a/examples/geolocation/app.js
+++ b/examples/geolocation/app.js
@@ -52,16 +52,6 @@ function main() {
     type: 'raster',
   }));
 
-  // Background layers change the background color of
-  // the map. They are not attached to a source.
-  store.dispatch(mapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
-
   // place the map on the page.
   ReactDOM.render(<Provider store={store}>
     <SdkMap>

--- a/examples/layer-list/app.js
+++ b/examples/layer-list/app.js
@@ -83,6 +83,19 @@ function main() {
     },
   }));
 
+  // Background layers change the background color of
+  // the map. They are not attached to a source.
+  store.dispatch(mapActions.addLayer({
+    id: 'background',
+    type: 'background',
+    paint: {
+      'background-color': '#eee',
+    },
+    metadata: {
+      'bnd:hide-layerlist': true,
+    },
+  }));
+
   // add the OSM source
   store.dispatch(mapActions.addSource('osm', {
     type: 'raster',

--- a/examples/paint-change/app.js
+++ b/examples/paint-change/app.js
@@ -56,16 +56,6 @@ function main() {
     data: {},
   }));
 
-  // Background layers change the background color of
-  // the map. They are not attached to a source.
-  store.dispatch(mapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
-
   // The points source has both null island
   // and random points on it. This layer
   // will style all random points as purple instead

--- a/examples/rotating/app.js
+++ b/examples/rotating/app.js
@@ -46,16 +46,6 @@ function main() {
     type: 'raster',
   }));
 
-  // Background layers change the background color of
-  // the map. They are not attached to a source.
-  store.dispatch(mapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
-
   const rotate = (dir) => {
     const bearing = store.getState().map.bearing;
     let calc;

--- a/examples/wfst/app.js
+++ b/examples/wfst/app.js
@@ -74,17 +74,6 @@ function main() {
     geometryName: 'geom',
   }));
 
-  // Background layers change the background color of
-  // the map. They are not attached to a source.
-  store.dispatch(SdkMapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
-
-
   // and an OSM layer.
   // Raster layers need not have any paint styles.
   store.dispatch(SdkMapActions.addLayer({

--- a/examples/wms/app.js
+++ b/examples/wms/app.js
@@ -49,15 +49,6 @@ function main() {
     type: 'raster',
   }));
 
-  // set the background color.
-  store.dispatch(mapActions.addLayer({
-    id: 'background',
-    type: 'background',
-    paint: {
-      'background-color': '#eee',
-    },
-  }));
-
   // retrieve GetCapabilities and give user ability to add a layer.
   const addWMS = () => {
     // this requires CORS headers on the geoserver instance.


### PR DESCRIPTION
SDK-773

In our examples we were sometimes using a background layer on top of an OSM layer. This doesn't make sense. I've removed the background layer from examples where it doesn't make sense (e.g. OSM layer for which visiblity cannot be changed), and I've added it to the layer list example, at the bottom of the layer stack, where OSM can actually be toggled so we get to see the background.