### PR TITLE
When receiving context, set layer and source version metadata

### DIFF
--- a/__tests__/reducers/map.test.js
+++ b/__tests__/reducers/map.test.js
@@ -250,6 +250,34 @@ describe('map reducer', () => {
     expect(reducer(state, action)).toEqual(context);
   });
 
+  it('should handle RECEIVE_CONTEXT with no metadata in context', () => {
+    const state = {
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      sources: {},
+      layers: [],
+    };
+    deepFreeze(state);
+    const context = {
+      version: 9,
+      name: 'foo',
+      center: [10, 10],
+      zoom: 4,
+      metadata: {
+        'bnd:layer-version': 1,
+        'bnd:source-version': 1,
+      },
+    };
+    const action = {
+      type: MAP.RECEIVE_CONTEXT,
+      context,
+    };
+    deepFreeze(action);
+    expect(reducer(state, action)).toEqual(context);
+  });
+
   it('should handle SET_LAYER_METADATA', () => {
     const title = 'Background';
     const layer = {

--- a/__tests__/reducers/map.test.js
+++ b/__tests__/reducers/map.test.js
@@ -223,6 +223,9 @@ describe('map reducer', () => {
       version: 8,
       name: 'default',
       center: [0, 0],
+      metadata: {
+        foo: 'bar',
+      },
       zoom: 3,
       sources: {},
       layers: [],
@@ -233,6 +236,11 @@ describe('map reducer', () => {
       name: 'foo',
       center: [10, 10],
       zoom: 4,
+      metadata: {
+        foo: 'bar',
+        'bnd:layer-version': 1,
+        'bnd:source-version': 1,
+      },
     };
     const action = {
       type: MAP.RECEIVE_CONTEXT,

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -555,12 +555,12 @@ export class Map extends React.Component {
 
     // check the sources diff
     const next_sources_version = getVersion(nextProps.map, SOURCE_VERSION_KEY);
-    if (next_sources_version === undefined || this.sourcesVersion !== next_sources_version) {
+    if (this.sourcesVersion !== next_sources_version) {
       // go through and update the sources.
       this.configureSources(nextProps.map.sources, next_sources_version);
     }
     const next_layer_version = getVersion(nextProps.map, LAYER_VERSION_KEY);
-    if (next_layer_version === undefined || this.layersVersion !== next_layer_version) {
+    if (this.layersVersion !== next_layer_version) {
       // go through and update the layers.
       this.configureLayers(nextProps.map.sources, nextProps.map.layers, next_layer_version);
     }

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -598,8 +598,11 @@ function setVisibility(state, action) {
  *  @returns {Object} The new state.
  */
 function setContext(state, action) {
-  // simply replace the full state
-  return Object.assign({}, action.context);
+  let metadata = incrementVersion(state.metadata, SOURCE_VERSION_KEY);
+  metadata = incrementVersion(metadata.metadata, LAYER_VERSION_KEY);
+  return Object.assign({}, action.context, {
+    metadata: Object.assign({}, metadata.metadata, action.context.metadata)
+  });
 }
 
 /** Update the map's metadata.


### PR DESCRIPTION
This came up during SDK-780, it made the code easier and more efficient to find differences if we set the metadata for layers and sources version when we receive a new context.