### PR TITLE
Move DND to a peer to fix compile time errors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "node-sass": "^4.5.3",
     "ol": "^4.4.2",
     "react": "^16.0.0",
+    "react-dnd": "^2.5.4",
+    "react-dnd-html5-backend": "^2.5.4",
     "react-dom": "^16.0.0",
     "react-redux": "^5.0.5",
     "react-test-renderer": "^16.0.0",
@@ -79,8 +81,6 @@
     "jest-cli": "^21.2.1",
     "ol-mapbox-style": "^2.6.1",
     "prop-types": "^15.5.10",
-    "react-dnd": "^2.5.4",
-    "react-dnd-html5-backend": "^2.5.4",
     "react-docgen": "^2.19.0",
     "uuid": "^3.1.0"
   },
@@ -88,6 +88,8 @@
     "ol": "^4.3.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-dnd": "^2.5.4",
+    "react-dnd-html5-backend": "^2.5.4",
     "react-redux": "^5.0.5",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0"


### PR DESCRIPTION
react-dnd / disposable was causing babelrc issues.