### PR TITLE
Make sure zoom levels are equal

### DIFF
--- a/__tests__/components/map-geojson-source.test.js
+++ b/__tests__/components/map-geojson-source.test.js
@@ -130,7 +130,7 @@ describe('tests for the geojson-type map sources', () => {
   it('adds a geojson feature collection with a BBOX', (done) => {
     // mock up the url to call
     nock('http://example.com')
-      .get('/base/bbox.geojson?BBOX=-978393.9620502561,-978393.9620502568,978393.9620502561,978393.9620502554')
+      .get('/base/bbox.geojson?BBOX=-489196.98102512804,-489196.98102512874,489196.98102512804,489196.98102512734')
       .reply(200, JSON.stringify(feature_collection));
 
     testGeojsonData(done, '/bbox.geojson?BBOX={bbox-epsg-3857}', 2);
@@ -152,7 +152,7 @@ describe('tests for the geojson-type map sources', () => {
 
     // mock up the url to call
     nock('http://example.com')
-      .get('/base/bbox.geojson?BBOX=-978393.9620502561,-978393.9620502568,978393.9620502561,978393.9620502554')
+      .get('/base/bbox.geojson?BBOX=-489196.98102512804,-489196.98102512874,489196.98102512804,489196.98102512734')
       .reply(200, JSON.stringify(feature_collection));
 
     const next_fetch = () => {

--- a/__tests__/components/map.test.js
+++ b/__tests__/components/map.test.js
@@ -447,7 +447,7 @@ describe('Map component', () => {
     instance.shouldComponentUpdate.call(instance, nextProps);
     // previous values should still be valid
     expect(radiansToDegrees(view.getRotation())).toBe(45);
-    expect(view.getZoom()).toBe(2);
+    expect(view.getZoom()).toBe(2 + 1);
     expect(view.getCenter()).toBe(centerWGS84);
   });
 
@@ -1049,7 +1049,7 @@ describe('Map component async', () => {
     // eslint-disable-next-line
     const response = {"type":"FeatureCollection","totalFeatures":"unknown","features":[{"type":"Feature","id":"bugsites.1","geometry":{"type":"Point","coordinates":[590232,4915039]},"geometry_name":"the_geom","properties":{"cat":1,"str1":"Beetle site"}}],"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::26713"}}};
     nock('http://example.com')
-      .get('/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&QUERY_LAYERS=bar&LAYERS=bar&INFO_FORMAT=application%2Fjson&I=0&J=255&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&STYLES=&BBOX=0%2C0%2C5009377.085697311%2C5009377.085697311')
+      .get('/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&QUERY_LAYERS=bar&LAYERS=bar&INFO_FORMAT=application%2Fjson&I=0&J=255&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&STYLES=&BBOX=0%2C0%2C2504688.5428486555%2C2504688.5428486555')
       .reply(200, response);
 
     sdk_map.sources = {

--- a/__tests__/components/map/__snapshots__/zoomslider.test.js.snap
+++ b/__tests__/components/map/__snapshots__/zoomslider.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Zoom slider tests should allow for custom className 1`] = `"<div class=\\"sdk-slider-control foo\\"><input type=\\"range\\" min=\\"0\\" max=\\"28\\" class=\\"sdk-zoom-slider\\" value=\\"3\\"></div>"`;
+exports[`Zoom slider tests should allow for custom className 1`] = `"<div class=\\"sdk-slider-control foo\\"><input type=\\"range\\" min=\\"0\\" max=\\"24\\" class=\\"sdk-zoom-slider\\" value=\\"3\\"></div>"`;

--- a/__tests__/reducers/map.test.js
+++ b/__tests__/reducers/map.test.js
@@ -92,6 +92,91 @@ describe('map reducer', () => {
     });
   });
 
+  it('should handle SET_VIEW max zoom constraint', () => {
+    const state = {
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      sources: {},
+      layers: [],
+    };
+    deepFreeze(state);
+    const action = {
+      type: MAP.SET_VIEW,
+      view: {
+        zoom: 25,
+        center: [10, 10],
+      },
+    };
+    deepFreeze(action);
+    expect(reducer(state, action)).toEqual({
+      version: 8,
+      name: 'default',
+      center: [10, 10],
+      zoom: 24,
+      sources: {},
+      layers: [],
+    });
+  });
+
+  it('should handle SET_VIEW min zoom constraint', () => {
+    const state = {
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      sources: {},
+      layers: [],
+    };
+    deepFreeze(state);
+    const action = {
+      type: MAP.SET_VIEW,
+      view: {
+        zoom: -1,
+        center: [10, 10],
+      },
+    };
+    deepFreeze(action);
+    expect(reducer(state, action)).toEqual({
+      version: 8,
+      name: 'default',
+      center: [10, 10],
+      zoom: 0,
+      sources: {},
+      layers: [],
+    });
+  });
+
+  it('should handle SET_VIEW zoom undefined', () => {
+    const state = {
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      sources: {},
+      layers: [],
+    };
+    deepFreeze(state);
+    const action = {
+      type: MAP.SET_VIEW,
+      view: {
+        center: [10, 10],
+        bearing: 5,
+      },
+    };
+    deepFreeze(action);
+    expect(reducer(state, action)).toEqual({
+      version: 8,
+      name: 'default',
+      center: [10, 10],
+      zoom: 3,
+      bearing: 5,
+      sources: {},
+      layers: [],
+    });
+  });
+
   it('should handle ZOOM_IN', () => {
     const state = {
       version: 8,
@@ -212,7 +297,7 @@ describe('map reducer', () => {
       version: 8,
       name: 'default',
       center: [0, 0],
-      zoom: 28,
+      zoom: 24,
       sources: {},
       layers: [],
     });

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -551,7 +551,7 @@ export class Map extends React.Component {
     }
     // compare the zoom
     if (nextProps.map.zoom !== undefined && (nextProps.map.zoom !== this.props.map.zoom)) {
-      map_view.setZoom(nextProps.map.zoom);
+      map_view.setZoom(nextProps.map.zoom + 1);
     }
     // compare the rotation
     if (nextProps.map.bearing !== undefined && nextProps.map.bearing !== this.props.map.bearing) {
@@ -1218,7 +1218,7 @@ export class Map extends React.Component {
       logo: false,
       view: new View({
         center,
-        zoom: this.props.map.zoom,
+        zoom: this.props.map.zoom >= 0 ? this.props.map.zoom + 1 : this.props.map.zoom,
         rotation,
         projection: map_proj,
       }),
@@ -1533,7 +1533,7 @@ function mapDispatchToProps(dispatch) {
       // transform the center to 4326 before dispatching the action.
       const center = Proj.transform(view.getCenter(), view.getProjection(), 'EPSG:4326');
       const rotation = radiansToDegrees(view.getRotation());
-      dispatch(setView(center, view.getZoom()));
+      dispatch(setView(center, view.getZoom() - 1));
       dispatch(setRotation(rotation));
     },
     setMeasureGeometry: (geometry, projection) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,7 +29,7 @@ export const QUERYABLE_KEY = 'bnd:queryable';
 
 export const DEFAULT_ZOOM = {
   MIN: 0,
-  MAX: 28,
+  MAX: 24,
 };
 
 export const INTERACTIONS = {

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -679,7 +679,11 @@ function setZoom(state, action) {
 export default function MapReducer(state = defaultState, action) {
   switch (action.type) {
     case MAP.SET_VIEW:
-      return Object.assign({}, state, action.view);
+      if (action.view.zoom !== undefined) {
+        return setZoom(Object.assign({}, state, action.view), {zoom: action.view.zoom});
+      } else {
+        return Object.assign({}, state, action.view);
+      }
     case MAP.ZOOM_IN:
       return setZoom(state, {zoom: state.zoom + 1});
     case MAP.ZOOM_OUT:


### PR DESCRIPTION
SDK-786

Mapbox GL JS (and the style spec) is based on 512 pixel tiles, so we need to adjust the openlayers zoom level