### PR TITLE
Move to ol 4.6.2 to fix sdk.boundlessgeo.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "mixin": "^0.2.0",
     "nock": "^9.0.13",
     "node-sass": "^4.5.3",
-    "ol": "^4.4.2",
+    "ol": "^4.6.2",
     "react": "^16.0.0",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",


### PR DESCRIPTION
https://sdk.boundlessgeo.com/basic/index.html is currently broken (all examples are) because of a bug in ol 4.6.0 that was used when the last build kicked off. This has been fixed in ol 4.6.2.

This kicks off a new build.

```
Uncaught Error: Cannot find module "../../layer/vectorrendertype.js"
```