### PR TITLE
No need to import app.css, this is handled by template

### DIFF
--- a/examples/feature-table/app.js
+++ b/examples/feature-table/app.js
@@ -27,8 +27,6 @@ import fetch from 'isomorphic-fetch';
 // This will have webpack include all of the SDK styles.
 import '@boundlessgeo/sdk/stylesheet/sdk.scss';
 
-// Use app.css to style current app
-
 /* eslint-disable no-underscore-dangle */
 const store = createStore(combineReducers({
   map: SdkMapReducer,

--- a/examples/wfst/app.js
+++ b/examples/wfst/app.js
@@ -31,8 +31,6 @@ import * as SdkMapActions from '@boundlessgeo/sdk/actions/map';
 // This will have webpack include all of the SDK styles.
 import '@boundlessgeo/sdk/stylesheet/sdk.scss';
 
-import './app.css';
-
 import EditPanel from './edit-panel';
 
 /* eslint-disable no-underscore-dangle */


### PR DESCRIPTION
This is a small fix to one of our examples. The example HTML template already handles the inclusion of app.css if it's present. https://github.com/boundlessgeo/sdk/blob/master/tasks/build-examples.js#L61:L66