### PR TITLE
Protect against not having .env file

### DIFF
--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -40,7 +40,7 @@ const config = {
     // Enables Hot Modules Replacement
     new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
-      MAPBOX_API_KEY: JSON.stringify(Config.parsed.MAPBOX_API_KEY),
+      MAPBOX_API_KEY: Config.parsed ? JSON.stringify(Config.parsed.MAPBOX_API_KEY) : undefined,
     }),
   ],
   module: {

--- a/webpack-example.config.js
+++ b/webpack-example.config.js
@@ -32,7 +32,7 @@ module.exports = {
       },
     }),
     new webpack.DefinePlugin({
-      MAPBOX_API_KEY: JSON.stringify(Config.parsed.MAPBOX_API_KEY),
+      MAPBOX_API_KEY: Config.parsed ? JSON.stringify(Config.parsed.MAPBOX_API_KEY) : undefined,
     }),
   ],
   module: {


### PR DESCRIPTION
Currently the examples are down because of this