### PR TITLE
Add requestHeaders to the addWfsSource (geojson) options

### DIFF
--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -518,7 +518,7 @@ export function addWmsSource(sourceId, serverUrl, layerName, options = {}) {
  * @returns {Object} Action to create a new source.
  */
 export function addWfsSource(sourceId, serverUrl, featureType, options = {}) {
-  const params = {
+  const params = Object.assign({
     'SERVICE': 'WFS',
     'VERSION': '1.1.0',
     // projection is always fixed for WFS sources as they
@@ -527,7 +527,7 @@ export function addWfsSource(sourceId, serverUrl, featureType, options = {}) {
     'REQUEST': 'GetFeature',
     'TYPENAME': featureType,
     'OUTPUTFORMAT': 'JSON',
-  };
+  }, options.params || {});
 
   if (options.accessToken) {
     params['ACCESS_TOKEN'] = options.accessToken;
@@ -535,7 +535,8 @@ export function addWfsSource(sourceId, serverUrl, featureType, options = {}) {
 
   return addSource(sourceId, {
     type: 'geojson',
-    data: `${serverUrl}?${encodeQueryObject(params)}`
+    data: `${serverUrl}?${encodeQueryObject(params)}`,
+    requestHeaders: options.requestHeaders
   });
 }
 

--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -518,7 +518,7 @@ export function addWmsSource(sourceId, serverUrl, layerName, options = {}) {
  * @returns {Object} Action to create a new source.
  */
 export function addWfsSource(sourceId, serverUrl, featureType, options = {}) {
-  const params = Object.assign({
+  const params = {
     'SERVICE': 'WFS',
     'VERSION': '1.1.0',
     // projection is always fixed for WFS sources as they
@@ -527,7 +527,7 @@ export function addWfsSource(sourceId, serverUrl, featureType, options = {}) {
     'REQUEST': 'GetFeature',
     'TYPENAME': featureType,
     'OUTPUTFORMAT': 'JSON',
-  }, options.params || {});
+  };
 
   if (options.accessToken) {
     params['ACCESS_TOKEN'] = options.accessToken;

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -281,7 +281,8 @@ function getLoaderFunction(glSource, mapProjection, baseUrl) {
       if (url.indexOf(BBOX_STRING) >= 0) {
         url = url.replace(BBOX_STRING, bbox.toString());
       }
-      features_promise = fetch(url).then(response => response.json());
+      features_promise = fetch(url, {headers: glSource.requestHeaders || {}})
+        .then(response => response.json());
     } else if (typeof glSource.data === 'object'
       && (glSource.data.type === 'Feature' || glSource.data.type === 'FeatureCollection')) {
       features_promise = new Promise((resolve) => {


### PR DESCRIPTION
Accepts `params` object in the `options` parameter of `addWfsSource()`.  The params will be added to the query string.
Accepts `requestHeaders` object in the `options` parameter of `addWfsSource()`.  The request headers will be set in the request to the server.
eg: 
```
SdkMapActions.addWfsSource(id, url, featureType, {
    params: {foo: 'bar', blah: 'blah'},
    requestHeaders: {"X-AUTH-TOKEN": 'abcdef', another: 'header'}
})
```