### PR TITLE
Allow setting className on ScaleLine

### DIFF
--- a/__tests__/components/map/__snapshots__/scaleline.test.js.snap
+++ b/__tests__/components/map/__snapshots__/scaleline.test.js.snap
@@ -29,3 +29,5 @@ exports[`Scaleline tests creates the meter suffix 1`] = `"<div class=\\"sdk-scal
 exports[`Scaleline tests creates the micrometer suffix 1`] = `"<div class=\\"sdk-scale-line\\"><div class=\\"sdk-scale-line-inner\\" style=\\"width: 70px;\\">500 μm</div></div>"`;
 
 exports[`Scaleline tests creates the millimeter suffix 1`] = `"<div class=\\"sdk-scale-line\\"><div class=\\"sdk-scale-line-inner\\" style=\\"width: 70px;\\">500 mm</div></div>"`;
+
+exports[`Scaleline tests should allow for custom className 1`] = `"<div class=\\"sdk-scale-line foo\\"><div class=\\"sdk-scale-line-inner\\" style=\\"width: 65px;\\">50 km</div></div>"`;

--- a/__tests__/components/map/scaleline.test.js
+++ b/__tests__/components/map/scaleline.test.js
@@ -26,6 +26,12 @@ describe('Scaleline tests', () => {
     store.dispatch(MapActions.setView([-98, 40], 4));
   });
 
+  it('should allow for custom className', () => {
+    store.dispatch(MapInfoActions.setResolution(1000));
+    const wrapper = mount(<ConnectedScaleLine className='foo' store={store} />);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
   it('create the correct scaleline', () => {
     store.dispatch(MapInfoActions.setResolution(1000));
     const wrapper = mount(<ConnectedScaleLine store={store} />);

--- a/src/components/layer-list.js
+++ b/src/components/layer-list.js
@@ -30,7 +30,7 @@ export class SdkList extends React.Component {
   }
 }
 
-SdkList.PropTypes = {
+SdkList.propTypes = {
   style: PropTypes.object,
   className: PropTypes.string,
   children: PropTypes.oneOfType([
@@ -62,7 +62,7 @@ export class SdkLayerListGroup extends React.Component {
   }
 }
 
-SdkLayerListGroup.PropTypes = {
+SdkLayerListGroup.propTypes = {
   enableDD: PropTypes.bool,
   groupId: PropTypes.string.isRequired,
   group: PropTypes.shape({

--- a/src/components/map/scaleline.js
+++ b/src/components/map/scaleline.js
@@ -118,6 +118,10 @@ export class ScaleLine extends React.Component {
   }
   render() {
     if (this.props.mapinfo && this.props.mapinfo.resolution !== null) {
+      let className = 'sdk-scale-line';
+      if (this.props.className) {
+        className += ' ' + this.props.className;
+      }
       const properties = this.calculateProperties();
       const pointResolution = properties.pointResolution;
       const suffix = properties.suffix;
@@ -137,7 +141,11 @@ export class ScaleLine extends React.Component {
         i += 1;
       }
       let html = count + ' ' + suffix;
-      return (<div style={this.props.style} className="sdk-scale-line"><div className="sdk-scale-line-inner" style={{width: width}} dangerouslySetInnerHTML={{__html: html}}></div></div>);
+      return (
+        <div style={this.props.style} className={className}>
+          <div className="sdk-scale-line-inner" style={{width: width}} dangerouslySetInnerHTML={{__html: html}}></div>
+        </div>
+      );
     } else {
       return false;
     }


### PR DESCRIPTION
This was a small oversight in #774 which did not allow for setting a custom className on the root div, which is actually needed for castling where we need two scalelines

cc @theduckylittle 