### PR TITLE
If legend depends on sprite, we need to wait for it to load

### DIFF
--- a/__tests__/components/__snapshots__/legend.test.js.snap
+++ b/__tests__/components/__snapshots__/legend.test.js.snap
@@ -11,3 +11,5 @@ exports[`test the Legend component should allow for vector (point) legend 1`] = 
 exports[`test the Legend component should allow for vector (polygon) legend 1`] = `"<div class=\\"sdk-legend\\"><canvas width=\\"50\\" height=\\"50\\" style=\\"width: 50px; height: 50px;\\"></canvas></div>"`;
 
 exports[`test the Legend component should allow for vector (symbol) legend 1`] = `"<div class=\\"sdk-legend\\"><canvas width=\\"50\\" height=\\"50\\" style=\\"width: 50px; height: 50px;\\"></canvas></div>"`;
+
+exports[`test the Legend component should render empty text 1`] = `"<div class=\\"sdk-legend\\">Empty Layer</div>"`;

--- a/__tests__/components/legend.test.js
+++ b/__tests__/components/legend.test.js
@@ -8,7 +8,7 @@ import  Adapter from 'enzyme-adapter-react-16';
 import {createStore, combineReducers} from 'redux';
 import MapReducer from '../../src/reducers/map';
 
-import SdkLegend from '../../src/components/legend';
+import SdkLegend, {Legend} from '../../src/components/legend';
 import {getLegend, getPointGeometry, getLineGeometry, getPolygonGeometry} from '../../src/components/legend';
 
 configure({adapter: new Adapter()});
@@ -155,6 +155,12 @@ describe('test the Legend component', () => {
     mount(<SdkLegend layerId="wms-test" store={store} />);
   });
 
+  it('should render empty text', () => {
+    const wrapper = mount(<Legend emptyLegendMessage='Empty Layer' layerId="wms-test" store={store} />);
+    wrapper.instance().setState({empty: true});
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
   it('should render a wms legend', () => {
     const wrapper = mount(<SdkLegend layerId="wms-test" store={store} />);
 
@@ -275,7 +281,8 @@ describe('test the Legend component', () => {
   });
 
   it('componentShouldReceiveProps should work correctly', () => {
-    const wrapper = mount(<SdkLegend layerId="vector-point-test" store={store} />);
+    const state = store.getState().map;
+    const wrapper = mount(<Legend layerId="vector-point-test" layers={state.layers} sources={state.sources} />);
     let layer;
     const layers = store.getState().map.layers;
     for (let i = 0, ii = layers.length; i < ii; ++i) {
@@ -284,7 +291,7 @@ describe('test the Legend component', () => {
         break;
       }
     }
-    const legend = wrapper.instance().getWrappedInstance();
+    const legend = wrapper.instance();
     let result = legend.componentWillReceiveProps({layers: [layer]});
     expect(result).toBe(false); // no need to update
     const newLayer = {id: 'vector-point-test'};

--- a/src/components/legend.js
+++ b/src/components/legend.js
@@ -247,7 +247,8 @@ export class Legend extends React.Component {
           );
           const olLayer = new VectorLayer();
           const me = this;
-          applyStyle(olLayer, fake_style, layer.source).then(function() {
+
+          const onApplyStyle = () => {
             const styleFn = olLayer.getStyle();
             let geom;
             if (layer.type === 'symbol' || layer.type === 'circle') {
@@ -273,6 +274,16 @@ export class Legend extends React.Component {
               } else {
                 me.setState({empty: true});
               }
+            }
+          };
+
+          applyStyle(olLayer, fake_style, layer.source).then(function() {
+            if (!(layer.layout && layer.layout['icon-image'])) {
+              onApplyStyle();
+            } else {
+              olLayer.once('change', () => {
+                onApplyStyle();
+              });
             }
           });
         }

--- a/src/components/legend.js
+++ b/src/components/legend.js
@@ -406,4 +406,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, undefined, undefined, {withRef: true})(Legend);
+export default connect(mapStateToProps)(Legend);


### PR DESCRIPTION
This came up with creating a legend for the castling app, some legends would not show up. This is because the sprite has not yet been loaded. If applyStyle finishes loading of the sprite image it will call changed on the vector layer, so we can use that hook.