### PR TITLE
Replace single time attribute with start and end

### DIFF
--- a/__tests__/components/map-time.test.js
+++ b/__tests__/components/map-time.test.js
@@ -124,7 +124,7 @@ describe('Map component time tests', () => {
 
     const layerConfig = {
       metadata: {
-        'bnd:timeattribute': 'time'
+        'bnd:start-time': 'time'
       },
       id: 'earthquakes',
       type: 'circle',

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,8 @@
 
 ### Next Release
 
+The name of the metadata key for filtering time-based datasets on the client has been changed from ```bnd:timeattribute``` to ```bnd:start-time``` and ```bnd:end-time``` where the last one is optional.
+
 ### v2.2.0
 
 #### ol package

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -75,7 +75,7 @@ import LoadingStrategy from 'ol/loadingstrategy';
 
 import {updateLayer, setView, setBearing} from '../actions/map';
 import {setMapSize, setMousePosition, setMapExtent, setResolution, setProjection} from '../actions/mapinfo';
-import {INTERACTIONS, LAYER_VERSION_KEY, SOURCE_VERSION_KEY, TIME_KEY, TIME_ATTRIBUTE_KEY, QUERYABLE_KEY, QUERY_ENDPOINT_KEY} from '../constants';
+import {INTERACTIONS, LAYER_VERSION_KEY, SOURCE_VERSION_KEY, TIME_KEY, TIME_START_KEY, QUERYABLE_KEY, QUERY_ENDPOINT_KEY} from '../constants';
 import {dataVersionKey} from '../reducers/map';
 
 import {setMeasureFeature, clearMeasureFeature} from '../actions/drawing';
@@ -548,7 +548,7 @@ export class Map extends React.Component {
       // find time dependent layers
       for (let i = 0, ii = nextProps.map.layers.length; i < ii; ++i) {
         const layer = nextProps.map.layers[i];
-        if (layer.metadata[TIME_ATTRIBUTE_KEY] !== undefined) {
+        if (layer.metadata[TIME_START_KEY] !== undefined) {
           this.props.updateLayer(layer.id, {
             filter: this.props.createLayerFilter(layer, nextProps.map.metadata[TIME_KEY])
           });

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -858,8 +858,8 @@ export class Map extends React.Component {
         this.applyStyle(layer, layers, sprite);
         return layer;
       case 'vector':
-        const time = this.props.map.metadata[TIME_KEY];
-        if (time && layers[0].metadata[TIME_START_KEY] !== undefined) {
+        const time = getKey(this.props.map.metadata, TIME_KEY);
+        if (time && layers[0].metadata && layers[0].metadata[TIME_START_KEY] !== undefined) {
           layers[0].filter = this.props.createLayerFilter(layers[0], time);
         }
         layer = new VectorTileLayer({

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -858,6 +858,10 @@ export class Map extends React.Component {
         this.applyStyle(layer, layers, sprite);
         return layer;
       case 'vector':
+        const time = this.props.map.metadata[TIME_KEY];
+        if (time && layers[0].metadata[TIME_START_KEY] !== undefined) {
+          layers[0].filter = this.props.createLayerFilter(layers[0], time);
+        }
         layer = new VectorTileLayer({
           declutter: declutter,
           source,

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,8 @@ export const LAYER_VERSION_KEY = 'bnd:layer-version';
 export const SOURCE_VERSION_KEY = 'bnd:source-version';
 export const TITLE_KEY = 'bnd:title';
 export const TIME_KEY = 'bnd:time';
-export const TIME_ATTRIBUTE_KEY = 'bnd:timeattribute';
+export const TIME_START_KEY = 'bnd:start-time';
+export const TIME_END_KEY = 'bnd:end-time';
 export const DATA_VERSION_KEY = 'bnd:data-version';
 export const GROUPS_KEY = 'mapbox:groups';
 export const GROUP_KEY = 'mapbox:group';
@@ -67,7 +68,8 @@ export default {
   TIME_KEY,
   GROUP_KEY,
   GROUPS_KEY,
-  TIME_ATTRIBUTE_KEY,
+  TIME_START_KEY,
+  TIME_END_KEY,
   DATA_VERSION_KEY,
   INTERACTIONS,
   DEFAULT_ZOOM,


### PR DESCRIPTION
When we initially designed the time based support, we had a single metadata attribute key for time based datasets. However is it common to have a start and an end attribute, where the second one is optional. This is also how it works in Exchange. So  this PR changes that behaviour. The actual filtering will still take place at the application level.