### PR TITLE
Change mapbox gl draw to use a single instance

### DIFF
--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -15,7 +15,8 @@ configure({adapter: new Adapter()});
 
 const createMapDrawMock = () => {
   return {
-    changeMode: () => {}
+    changeMode: () => {},
+    getAll: () => {},
   };
 };
 const createMapMock = () => {
@@ -512,11 +513,12 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance();
     // mock up our GL map
     map.map = createMapMock();
+    map.draw = createMapDrawMock();
     const on = () => {};
     map.map.on = on;
-    spyOn(map.map, 'addControl');
+    spyOn(map.draw, 'changeMode');
     map.updateInteraction({interaction: 'measure:LineString'});
-    expect(map.map.addControl).toHaveBeenCalled();
+    expect(map.draw.changeMode).toHaveBeenCalled();
   });
 
   it('should call setView', () => {
@@ -739,11 +741,11 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance();
     // mock up our GL map
     map.map = createMapMock();
-    map.onDrawRender({
-      getAll: () => {
-        return {features: [{geometry: {}}]};
-      }
-    });
+    map.draw = createMapDrawMock();
+    map.draw.getAll = () => {
+      return {features: [{geometry: {}}]};
+    };
+    map.onDrawRender({});
     window.setTimeout(function() {
       expect(props.setMeasureGeometry).toHaveBeenCalled();
       done();
@@ -759,11 +761,11 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance().getWrappedInstance();
     // mock up our GL map
     map.map = createMapMock();
-    map.onDrawRender({
-      getAll: () => {
-        return {features: [{geometry: {type: 'LineString', coordinates: [[0, 10], [0, 20]]}}]};
-      }
-    });
+    map.draw = createMapDrawMock();
+    map.draw.getAll = () => {
+      return {features: [{geometry: {type: 'LineString', coordinates: [[0, 10], [0, 20]]}}]};
+    };
+    map.onDrawRender({});
     window.setTimeout(function() {
       expect(store.getState().draw.measureSegments).toEqual([1111.9508023353287]);
       done();
@@ -779,11 +781,11 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance().getWrappedInstance();
     // mock up our GL map
     map.map = createMapMock();
-    map.onDrawRender({
-      getAll: () => {
-        return {features: [{geometry: {type: 'Polygon', coordinates: [[[0, 10], [0, 20], [10, 10], [10, 20], [0, 10]]]}}]};
-      }
-    });
+    map.draw = createMapDrawMock();
+    map.draw.getAll = () => {
+      return {features: [{geometry: {type: 'Polygon', coordinates: [[[0, 10], [0, 20], [10, 10], [10, 20], [0, 10]]]}}]};
+    };
+    map.onDrawRender({});
     window.setTimeout(function() {
       expect(store.getState().draw.measureSegments).toEqual([0.00014113929327614141]);
       done();

--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -84,6 +84,9 @@ describe('MapboxGL component', () => {
     const sources = {
       geojson: {
         type: 'geojson',
+        data: {
+          features: []
+        }
       },
     };
     const layers = [];
@@ -129,8 +132,6 @@ describe('MapboxGL component', () => {
       types.push(type);
     };
     map.map.on = on;
-    const addControl = () => {};
-    map.map.addControl = addControl;
     const removeControl = () => {};
     map.map.removeControl = removeControl;
     spyOn(map.map, 'removeControl');
@@ -478,8 +479,6 @@ describe('MapboxGL component', () => {
     map.draw = createMapDrawMock();
     const on = () => {};
     map.map.on = on;
-    const addControl = () => {};
-    map.map.addControl = addControl;
     spyOn(map.draw, 'changeMode');
     map.updateInteraction({interaction: 'Polygon'});
     expect(map.draw.changeMode).toHaveBeenCalled();
@@ -515,8 +514,6 @@ describe('MapboxGL component', () => {
     map.map = createMapMock();
     const on = () => {};
     map.map.on = on;
-    const addControl = () => {};
-    map.map.addControl = addControl;
     spyOn(map.map, 'addControl');
     map.updateInteraction({interaction: 'measure:LineString'});
     expect(map.map.addControl).toHaveBeenCalled();

--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -13,6 +13,11 @@ import SdkPopup from '../../src/components/map/popup';
 
 configure({adapter: new Adapter()});
 
+const createMapDrawMock = () => {
+  return {
+    changeMode: () => {}
+  };
+};
 const createMapMock = () => {
   return {
     getSource: () => {
@@ -25,6 +30,7 @@ const createMapMock = () => {
     setCenter: () => {},
     setBearing: () => {},
     setZoom: () => {},
+    addControl: () => {},
     queryRenderedFeatures: () => {
       return [{
         layer: {
@@ -97,6 +103,7 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance();
     // mock up our GL map
     map.map = createMapMock();
+    map.draw = createMapDrawMock();
     spyOn(map.map, 'setStyle');
     spyOn(map.map, 'setCenter');
     spyOn(map.map, 'setBearing');
@@ -141,7 +148,6 @@ describe('MapboxGL component', () => {
     };
     map.shouldComponentUpdate(nextProps);
     expect(map.updateInteraction).toHaveBeenCalled();
-    expect(map.map.removeControl).toHaveBeenCalled();
     delete nextProps.map.metadata;
     nextProps.map.sources = {};
     map.shouldComponentUpdate(nextProps);
@@ -469,13 +475,14 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance();
     // mock up our GL map
     map.map = createMapMock();
+    map.draw = createMapDrawMock();
     const on = () => {};
     map.map.on = on;
     const addControl = () => {};
     map.map.addControl = addControl;
-    spyOn(map.map, 'addControl');
+    spyOn(map.draw, 'changeMode');
     map.updateInteraction({interaction: 'Polygon'});
-    expect(map.map.addControl).toHaveBeenCalled();
+    expect(map.draw.changeMode).toHaveBeenCalled();
   });
 
   it('updateInteraction with measure works correctly', () => {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jsdoc": "npm run build:doc-css && npm run build:jsdoc"
   },
   "devDependencies": {
+    "@mapbox/mapbox-gl-draw-static-mode": "^1.0.1",
     "@mapbox/mapbox-gl-draw": "^1.0.4",
     "@turf/area": "^5.0.4",
     "@turf/distance": "^5.0.4",
@@ -93,6 +94,7 @@
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
+    "@mapbox/mapbox-gl-draw-static-mode": "^1.0.1",
     "@mapbox/mapbox-gl-draw": "^1.0.4",
     "@turf/area": "^5.0.4",
     "@turf/distance": "^5.0.4",

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -135,7 +135,7 @@ export class MapboxGL extends React.Component {
             this.props.map.metadata[version_key] !== nextProps.map.metadata[version_key] && this.map) {
           this.map.getSource(src_name).setData(nextProps.map.sources[src_name].data);
           if (this.draw) {
-            if (this.map.getSource(src_name).type === 'geojson') {
+            if (nextProps.map.sources[src_name].type === 'geojson') {
               nextProps.map.sources[src_name].data.features.forEach((feature) => {
                 this.draw.add(feature);
               });
@@ -234,7 +234,7 @@ export class MapboxGL extends React.Component {
         this.map.on('load', this.onMapLoad);
       }
       if (!this.draw) {
-        var modes = MapboxDraw.modes;
+        const modes = MapboxDraw.modes;
         modes.static = StaticMode;
         const drawOptions = {displayControlsDefault: false, modes: modes, defaultMode: 'static'};
         this.draw = new MapboxDraw(drawOptions);

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -296,8 +296,8 @@ export class MapboxGL extends React.Component {
     }, 0);
   }
 
-  onDrawRender(measure) {
-    const collection = measure.getAll();
+  onDrawRender(evt) {
+    const collection = this.draw.getAll();
     if (collection.features.length > 0) {
       this.props.setMeasureGeometry(collection.features[0].geometry);
     }
@@ -331,15 +331,10 @@ export class MapboxGL extends React.Component {
       // but are prefixed with "measure:"
       const measureType = drawingProps.interaction.split(':')[1];
       defaultMode = this.getMode(measureType);
-      const measure = new MapboxDraw({
-        displayControlsDefault: false,
-        defaultMode,
-      });
+      this.draw.changeMode(defaultMode);
       this.map.on('draw.render', (evt) => {
-        this.onDrawRender(measure);
+        this.onDrawRender(evt);
       });
-
-      this.activeInteractions = [measure];
     } else {
       this.draw.changeMode('static');
     }


### PR DESCRIPTION
## What does this PR do?
Updates the support for mapbox draw. It was not working properly. 

### Reasons:
multiple instances of Draw do not share any information and would
destroy all features and elements. rather than creating a new instance
we simply change the mode of them.
the static mode which does not allow anything is the default mode