### PR TITLE
Add ability to set modes for drawing

### DIFF
--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -790,7 +790,7 @@ describe('MapboxGL component', () => {
       interaction: 'Modify',
       sourceName: 'geojson',
     };
-    map.updateInteraction(drawingProps)
+    map.updateInteraction(drawingProps);
     expect(map.currentMode).toEqual('simple_select');
     expect(map.afterMode).toEqual('direct_select');
   });

--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -752,6 +752,49 @@ describe('MapboxGL component', () => {
     }, 0);
   });
 
+  it('optionsForMode returns featureId object', () => {
+    const wrapper = shallow(<MapboxGL />);
+    const map = wrapper.instance();
+    // mock up our GL map
+    map.map = createMapMock();
+    map.draw = createMapDrawMock();
+    expect(map.optionsForMode('direct_select', {features: [{id: 1}]})).toEqual({featureId: 1});
+  });
+
+  it('setMode returns the currentMode if afterMode is not set', () => {
+    const wrapper = shallow(<MapboxGL />);
+    const map = wrapper.instance();
+    // mock up our GL map
+    map.map = createMapMock();
+    map.draw = createMapDrawMock();
+    expect(map.setMode('direct_select')).toEqual('direct_select');
+  });
+
+  it('setMode returns after if afterMode is set', () => {
+    const wrapper = shallow(<MapboxGL />);
+    const map = wrapper.instance();
+    // mock up our GL map
+    map.map = createMapMock();
+    map.draw = createMapDrawMock();
+    expect(map.setMode('direct_select', 'simple_select')).toEqual('simple_select');
+  });
+
+  it('setMode returns after if afterMode is set', () => {
+    const wrapper = shallow(<MapboxGL />);
+    const map = wrapper.instance();
+    // mock up our GL map
+    map.map = createMapMock();
+    map.draw = createMapDrawMock();
+    map.addedDrawListener = true;
+    const drawingProps = {
+      interaction: 'Modify',
+      sourceName: 'geojson',
+    };
+    map.updateInteraction(drawingProps)
+    expect(map.currentMode).toEqual('simple_select');
+    expect(map.afterMode).toEqual('direct_select');
+  });
+
   it('setMeasureGeometry works correctly for LineString', (done) => {
     const store = createStore(combineReducers({
       map: MapReducer,

--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -779,7 +779,7 @@ describe('MapboxGL component', () => {
     expect(map.setMode('direct_select', 'simple_select')).toEqual('simple_select');
   });
 
-  it('setMode returns after if afterMode is set', () => {
+  it('default modes are simple_select and direct_select for modify interaction', () => {
     const wrapper = shallow(<MapboxGL />);
     const map = wrapper.instance();
     // mock up our GL map

--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -137,7 +137,7 @@ describe('MapboxGL component', () => {
     map.map.removeControl = removeControl;
     spyOn(map.map, 'removeControl');
     map.shouldComponentUpdate(nextProps);
-    expect(types).toEqual(['draw.create']);
+    expect(types).toEqual(['draw.create', 'draw.update']);
     expect(map.map.setStyle).toHaveBeenCalled();
     expect(map.map.setCenter).toHaveBeenCalled();
     expect(map.map.setBearing).toHaveBeenCalled();

--- a/__tests__/reducers/drawing.test.js
+++ b/__tests__/reducers/drawing.test.js
@@ -13,6 +13,8 @@ describe('drawing reducer', () => {
       sourceName: null,
       measureFeature: null,
       measureSegments: null,
+      currentMode: null,
+      afterMode: null,
       measureDone: false,
       editStyle: null,
       modifyStyle: null,
@@ -36,6 +38,8 @@ describe('drawing reducer', () => {
       sourceName: source_name,
       measureFeature: null,
       measureSegments: null,
+      currentMode: undefined,
+      afterMode: undefined,
       measureDone: false,
       editStyle: null,
       modifyStyle: null,
@@ -55,6 +59,8 @@ describe('drawing reducer', () => {
     const expected_state = {
       interaction: null,
       sourceName: null,
+      currentMode: undefined,
+      afterMode: undefined,
       measureDone: false,
       measureFeature: null,
       measureSegments: null,
@@ -85,6 +91,8 @@ describe('drawing reducer', () => {
     expect(state).toEqual({
       interaction: null,
       sourceName: null,
+      currentMode: null,
+      afterMode: null,
       measureFeature: line,
       measureSegments: segs,
       measureDone: false,
@@ -97,6 +105,8 @@ describe('drawing reducer', () => {
     expect(cleared_state).toEqual({
       interaction: null,
       sourceName: null,
+      currentMode: null,
+      afterMode: null,
       measureFeature: null,
       measureSegments: null,
       measureDone: false,
@@ -129,6 +139,8 @@ describe('drawing reducer', () => {
     expect(state).toEqual({
       interaction: null,
       sourceName: null,
+      currentMode: null,
+      afterMode: null,
       measureFeature: line,
       measureSegments: segs,
       measureDone: true,
@@ -150,6 +162,8 @@ describe('drawing reducer', () => {
     const expected_state = {
       interaction: null,
       sourceName: null,
+      currentMode: null,
+      afterMode: null,
       measureFeature: null,
       measureSegments: null,
       measureDone: false,
@@ -172,6 +186,8 @@ describe('drawing reducer', () => {
     const expected_state = {
       interaction: null,
       sourceName: null,
+      currentMode: null,
+      afterMode: null,
       measureFeature: null,
       measureSegments: null,
       measureDone: false,
@@ -194,6 +210,8 @@ describe('drawing reducer', () => {
     const expected_state = {
       interaction: null,
       sourceName: null,
+      currentMode: null,
+      afterMode: null,
       measureFeature: null,
       measureSegments: null,
       measureDone: false,
@@ -216,6 +234,8 @@ describe('drawing reducer', () => {
     const expected_state = {
       interaction: null,
       sourceName: null,
+      currentMode: null,
+      afterMode: null,
       measureFeature: null,
       measureSegments: null,
       measureDone: false,
@@ -236,6 +256,8 @@ describe('drawing reducer', () => {
     const expected_state_in_between = {
       interaction: geo_type,
       sourceName: source_name,
+      currentMode: null,
+      afterMode: null,
       measureFeature: null,
       measureSegments: null,
       measureDone: false,

--- a/__tests__/reducers/drawing.test.js
+++ b/__tests__/reducers/drawing.test.js
@@ -256,8 +256,8 @@ describe('drawing reducer', () => {
     const expected_state_in_between = {
       interaction: geo_type,
       sourceName: source_name,
-      currentMode: null,
-      afterMode: null,
+      currentMode: undefined,
+      afterMode: undefined,
       measureFeature: null,
       measureSegments: null,
       measureDone: false,
@@ -265,8 +265,22 @@ describe('drawing reducer', () => {
       modifyStyle: null,
       selectStyle: null
     };
+
+    const expected_end_state = {
+      interaction: null,
+      sourceName: null,
+      currentMode: undefined,
+      afterMode: undefined,
+      measureFeature: null,
+      measureSegments: null,
+      measureDone: false,
+      editStyle: editStyle,
+      modifyStyle: null,
+      selectStyle: null
+    };
+
     deepFreeze(test_action_start);
     expect(reducer(expected_state, test_action_start)).toEqual(expected_state_in_between);
-    expect(reducer(expected_state_in_between, {type: DRAWING.END})).toEqual(expected_state);
+    expect(reducer(expected_state_in_between, {type: DRAWING.END})).toEqual(expected_end_state);
   });
 });

--- a/examples/drawing/app.js
+++ b/examples/drawing/app.js
@@ -213,7 +213,7 @@ function main() {
     if (drawing_tool === 'none') {
       store.dispatch(drawingActions.endDrawing());
     } else if (drawing_layer !== null) {
-      store.dispatch(drawingActions.startDrawing(drawing_layer, drawing_tool));
+      store.dispatch(drawingActions.startDrawing(drawing_layer, drawing_tool, 'direct_select'));
     }
   };
 

--- a/src/actions/drawing.js
+++ b/src/actions/drawing.js
@@ -24,11 +24,13 @@ import {INTERACTIONS} from '../constants';
  *
  *  @returns {Object} An action object to pass to the reducer.
  */
-export function startDrawing(sourceName, drawingType) {
+export function startDrawing(sourceName, drawingType, afterMode, currentMode) {
   return {
     type: DRAWING.START,
     interaction: drawingType,
     sourceName,
+    currentMode,
+    afterMode,
   };
 }
 
@@ -37,8 +39,8 @@ export function startDrawing(sourceName, drawingType) {
  *
  *  @returns {Object} Call to startDrawing()
  */
-export function startModify(sourceName) {
-  return startDrawing(sourceName, INTERACTIONS.modify);
+export function startModify(sourceName, afterMode, currentMode) {
+  return startDrawing(sourceName, INTERACTIONS.modify, afterMode, currentMode);
 }
 
 /** Short-hand action to start select-feature
@@ -53,17 +55,18 @@ export function startSelect(sourceName) {
 /** Stop drawing / select / modify
  *  @returns {Object} An action object to pass to the reducer.
  */
-export function endDrawing() {
+export function endDrawing(afterMode) {
   return {
     type: DRAWING.END,
+    afterMode,
   };
 }
 
 /** These are just aliases to end drawing.
  *  @returns {Object} Call to endDrawing().
  */
-export function endModify() {
-  return endDrawing();
+export function endModify(afterMode) {
+  return endDrawing(afterMode);
 }
 
 /** These are just aliases to end drawing.

--- a/src/actions/drawing.js
+++ b/src/actions/drawing.js
@@ -21,6 +21,8 @@ import {INTERACTIONS} from '../constants';
 /** Action to start an interaction on the map.
  *  @param {string} sourceName The name of the source on which the action takes place.
  *  @param {string} drawingType The type of drawing interaction.
+ *  @param {string} afterMode The mode to be used after the drawing interaction finishes.
+ *  @param {string} currentMode The mode to be used for drawing interaction.
  *
  *  @returns {Object} An action object to pass to the reducer.
  */
@@ -36,6 +38,8 @@ export function startDrawing(sourceName, drawingType, afterMode, currentMode) {
 
 /** Short-hand action to start modify-feature
  *  @param {string} sourceName The name of the source to modify.
+ *  @param {string} afterMode The mode to be used after the drawing interaction finishes.
+ *  @param {string} currentMode The mode to be used for drawing interaction.
  *
  *  @returns {Object} Call to startDrawing()
  */
@@ -53,6 +57,8 @@ export function startSelect(sourceName) {
 }
 
 /** Stop drawing / select / modify
+ *  @param {string} afterMode The mode to be used after the drawing interaction finishes.
+ *
  *  @returns {Object} An action object to pass to the reducer.
  */
 export function endDrawing(afterMode) {
@@ -63,6 +69,8 @@ export function endDrawing(afterMode) {
 }
 
 /** These are just aliases to end drawing.
+ *  @param {string} afterMode The mode to be used after the drawing interaction finishes.
+ *
  *  @returns {Object} Call to endDrawing().
  */
 export function endModify(afterMode) {

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -39,6 +39,10 @@ const isBrowser = !(
 
 const mapboxgl = isBrowser ? require('mapbox-gl') : null;
 
+const SIMPLE_SELECT_MODE = 'simple_select';
+const DIRECT_SELECT_MODE = 'direct_select';
+const STATIC_MODE = 'static';
+
 /** @module components/map
  *
  * @desc Provide a Mapbox GL map which reflects the
@@ -77,8 +81,8 @@ export class MapboxGL extends React.Component {
     this.drawMode = StaticMode;
     this.addedDrawListener = false;
     this.addedMeasurementListener = false;
-    this.currentMode = 'static';
-    this.afterMode = 'static';
+    this.currentMode = STATIC_MODE;
+    this.afterMode = STATIC_MODE;
 
     // interactions are how the user can manipulate the map,
     //  this tracks any active interaction.
@@ -245,7 +249,7 @@ export class MapboxGL extends React.Component {
           });
         }
         modes.static = StaticMode;
-        const drawOptions = {displayControlsDefault: false, modes: modes, defaultMode: 'static'};
+        const drawOptions = {displayControlsDefault: false, modes: modes, defaultMode: STATIC_MODE};
         this.draw = new MapboxDraw(drawOptions);
         this.map.addControl(this.draw);
       }
@@ -316,7 +320,7 @@ export class MapboxGL extends React.Component {
   }
 
   optionsForMode(mode, evt) {
-    if (mode === 'direct_select') {
+    if (mode === DIRECT_SELECT_MODE) {
       return {featureId: evt.features[0].id};
     }
     return {};
@@ -336,9 +340,9 @@ export class MapboxGL extends React.Component {
       this.afterMode = this.setMode(this.currentMode, drawingProps.afterMode);
       this.draw.changeMode(this.currentMode);
     } else if (INTERACTIONS.modify === drawingProps.interaction || INTERACTIONS.select === drawingProps.interaction) {
-      this.currentMode = this.setMode('simple_select', drawingProps.currentMode);
+      this.currentMode = this.setMode(SIMPLE_SELECT_MODE, drawingProps.currentMode);
       this.draw.changeMode(this.currentMode);
-      this.afterMode = this.setMode('direct_select', drawingProps.afterMode);
+      this.afterMode = this.setMode(DIRECT_SELECT_MODE, drawingProps.afterMode);
     } else if (INTERACTIONS.measuring.includes(drawingProps.interaction)) {
       // clear the previous measure feature.
       this.props.clearMeasureFeature();
@@ -354,7 +358,7 @@ export class MapboxGL extends React.Component {
         this.addedMeasurementListener = true;
       }
     } else {
-      this.draw.changeMode('static');
+      this.draw.changeMode(STATIC_MODE);
     }
     if (!this.addedDrawListener) {
       if (drawingProps.sourceName) {

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -76,6 +76,7 @@ export class MapboxGL extends React.Component {
     this.draw = null;
     this.drawMode = StaticMode;
     this.addedDrawListener = false;
+    this.addedMeasurementListener = false;
     this.currentMode = 'static';
     this.afterMode = 'static';
 
@@ -350,21 +351,22 @@ export class MapboxGL extends React.Component {
         this.map.on('draw.render', (evt) => {
           this.onDrawRender(evt);
         });
+        this.addedMeasurementListener = true;
       }
     } else {
       this.draw.changeMode('static');
     }
     if (!this.addedDrawListener) {
       if (drawingProps.sourceName) {
-        this.addedDrawListener = true;
         const drawCreate = (evt) => {
           this.onDrawCreate(evt, drawingProps, this.draw, this.afterMode, this.optionsForMode(this.afterMode, evt));
         };
         const drawModify =  (evt) => {
           this.onDrawModify(evt, drawingProps, this.draw, this.afterMode, this.optionsForMode(this.afterMode, evt));
         };
-        this.map.on('draw.create', drawCreate.bind(this));
-        this.map.on('draw.update', drawModify.bind(this));
+        this.map.on('draw.create', drawCreate);
+        this.map.on('draw.update', drawModify);
+        this.addedDrawListener = true;
       }
     }
 
@@ -499,7 +501,7 @@ MapboxGL.propTypes = {
   }),
   /** Initial popups to display in the map. */
   initialPopups: PropTypes.arrayOf(PropTypes.object),
-  /** Inital drawing modes that are available for drawing */
+  /** Initial drawing modes that are available for drawing */
   drawingModes: PropTypes.arrayOf(PropTypes.object),
   /** setView callback function, triggered on moveend. */
   setView: PropTypes.func,

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -315,14 +315,18 @@ export class MapboxGL extends React.Component {
     if (INTERACTIONS.drawing.includes(drawingProps.interaction)) {
       defaultMode = this.getMode(drawingProps.interaction);
       this.draw.changeMode(defaultMode);
-      this.map.on('draw.create', (evt) => {
+      const onDrawCreate = (evt) => {
         this.onDrawCreate(evt, drawingProps, this.draw, defaultMode);
-      });
+      };
+      this.map.off('draw.create', onDrawCreate);
+      this.map.on('draw.create', onDrawCreate);
     } else if (INTERACTIONS.modify === drawingProps.interaction || INTERACTIONS.select === drawingProps.interaction) {
       this.draw.changeMode('simple_select');
-      this.map.on('draw.update', (evt) => {
+      const onDrawModify = (evt) => {
         this.onDrawModify(evt, drawingProps, this.draw, 'direct_select', {featureId: evt.features[0].id});
-      });
+      };
+      this.map.off('draw.update', onDrawModify);
+      this.map.on('draw.update', onDrawModify);
     } else if (INTERACTIONS.measuring.includes(drawingProps.interaction)) {
       // clear the previous measure feature.
       this.props.clearMeasureFeature();
@@ -331,9 +335,11 @@ export class MapboxGL extends React.Component {
       const measureType = drawingProps.interaction.split(':')[1];
       defaultMode = this.getMode(measureType);
       this.draw.changeMode(defaultMode);
-      this.map.on('draw.render', (evt) => {
+      const onDrawRender = (evt) => {
         this.onDrawRender(evt);
-      });
+      };
+      this.map.off('draw.render', onDrawRender);
+      this.map.on('draw.render', onDrawRender);
     } else {
       this.draw.changeMode('static');
     }

--- a/src/reducers/drawing.js
+++ b/src/reducers/drawing.js
@@ -26,6 +26,8 @@ const defaultState = {
   sourceName: null,
   measureFeature: null,
   measureSegments: null,
+  currentMode: null,
+  afterMode: null,
   measureDone: false,
   editStyle: null,
   modifyStyle: null,
@@ -45,6 +47,8 @@ export default function drawingReducer(state = defaultState, action) {
       return Object.assign({}, state, {
         interaction: null,
         sourceName: null,
+        currentMode: action.currentMode,
+        afterMode: action.afterMode,
         measureDone: false,
         measureFeature: null,
         measureSegments: null
@@ -53,6 +57,8 @@ export default function drawingReducer(state = defaultState, action) {
       return Object.assign({}, state, {
         interaction: action.interaction,
         sourceName: action.sourceName,
+        currentMode: action.currentMode,
+        afterMode: action.afterMode,
         measureDone: false,
         measureFeature: null,
         measureSegments: null,


### PR DESCRIPTION
## What does this PR do?
It adds the ability to change the modes for every interaction. 
And change the mode that will be used after the interaction is finished. 

### Why this change?
it is possible with mapbox draw to have custom modes, this PR adds the
ability to assign them to the map and change them with the call to the
interactions.
there will be a mode for the interaction itself and one to switch to
after the interaction is done.
for example you want to draw new features, but after the feature is done
you don't want toi create another feature but rather change the newly
created one.
### Fixes
_Checks if the listener was added before and does not add them again_

this caused a bug in our system, that changing the mode often would cause the callback to be called multiple times. 
prevent that by checking if the listener was already added. it has to be made with `bind`  and at this place, because we need more info than just the event.