### PR TITLE
Async creation of sources

### DIFF
--- a/__tests__/actions/map.test.js
+++ b/__tests__/actions/map.test.js
@@ -505,7 +505,7 @@ describe('async actions', () => {
     const sourceName = 'my-source';
     const sourceDef = {
       type: 'vector',
-      url: 'http://localhost/geoserver/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=application%2Fx-protobuf%3Btype%3Dmapbox-vector&TRANSPARENT=TRUE&LAYERS=my-layer&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX={bbox-epsg-3857}',
+      tiles: ['http://localhost/geoserver/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=application%2Fx-protobuf%3Btype%3Dmapbox-vector&TRANSPARENT=TRUE&LAYERS=my-layer&WIDTH=256&HEIGHT=256&CRS=EPSG%3A3857&BBOX={bbox-epsg-3857}'],
     };
     expect(actions.addWmsSource(sourceName, 'http://localhost/geoserver/wms', 'my-layer')).toEqual({
       type: MAP.ADD_SOURCE,
@@ -518,7 +518,7 @@ describe('async actions', () => {
     const sourceName = 'my-source';
     const sourceDef = {
       type: 'vector',
-      url: 'http://localhost/geoserver/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=application%2Fx-protobuf%3Btype%3Dmapbox-vector&TRANSPARENT=TRUE&LAYERS=my-layer&WIDTH=512&HEIGHT=512&CRS=EPSG%3A4326&ACCESS_TOKEN=my-token&BBOX={bbox-epsg-3857}',
+      tiles: ['http://localhost/geoserver/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=application%2Fx-protobuf%3Btype%3Dmapbox-vector&TRANSPARENT=TRUE&LAYERS=my-layer&WIDTH=512&HEIGHT=512&CRS=EPSG%3A4326&ACCESS_TOKEN=my-token&BBOX={bbox-epsg-3857}'],
     };
     const options = {accessToken: 'my-token', projection: 'EPSG:4326', tileSize: 512};
     expect(actions.addWmsSource(sourceName, 'http://localhost/geoserver/wms', 'my-layer', options)).toEqual({
@@ -580,7 +580,7 @@ describe('async actions', () => {
     const options = {accessToken: 'my-token'};
     const sourceDef = {
       type: 'vector',
-      url: 'http://localhost/geoserver/gwc/service/tms/1.0.0/topp:states@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf?access_token=my-token',
+      tiles: ['http://localhost/geoserver/gwc/service/tms/1.0.0/topp:states@EPSG%3A3857@pbf/{z}/{x}/{-y}.pbf?access_token=my-token'],
     };
     expect(actions.addTmsSource(sourceName, url, layerName, options)).toEqual({
       type: MAP.ADD_SOURCE,

--- a/__tests__/components/map-cluster.test.js
+++ b/__tests__/components/map-cluster.test.js
@@ -85,17 +85,23 @@ describe('tests for cluster map sources', () => {
         const feature = cluster.getFeatures()[0];
         expect(feature.getGeometry().getCoordinates()[0]).not.toBe(5.5);
         store.dispatch(MapActions.setClusterRadius(src_name, 10));
-        cluster = map.sources[src_name];
-        expect(cluster.getDistance()).toBe(10);
-        store.dispatch(MapActions.clusterPoints(src_name, false));
-        cluster = map.sources[src_name];
-        expect(cluster).toBeInstanceOf(VectorSource);
-        // re cluster and check radius
-        store.dispatch(MapActions.clusterPoints(src_name, true));
-        cluster = map.sources[src_name];
-        expect(cluster).toBeInstanceOf(SdkClusterSource);
-        expect(cluster.getDistance()).toBe(10);
-        done();
+        window.setTimeout(() => {
+          cluster = map.sources[src_name];
+          expect(cluster.getDistance()).toBe(10);
+          store.dispatch(MapActions.clusterPoints(src_name, false));
+          window.setTimeout(() => {
+            cluster = map.sources[src_name];
+            expect(cluster).toBeInstanceOf(VectorSource);
+            // re cluster and check radius
+            store.dispatch(MapActions.clusterPoints(src_name, true));
+            window.setTimeout(() => {
+              cluster = map.sources[src_name];
+              expect(cluster).toBeInstanceOf(SdkClusterSource);
+              expect(cluster.getDistance()).toBe(10);
+              done();
+            }, 0);
+          }, 0);
+        }, 0);
       }, 100);
     }, 100);
   });

--- a/__tests__/components/map-context.test.js
+++ b/__tests__/components/map-context.test.js
@@ -18,7 +18,7 @@ import * as MapActions from '../../src/actions/map';
 configure({adapter: new Adapter()});
 
 describe('Map component context documents', () => {
-  it('should correctly reload context documents', () => {
+  it('should correctly reload context documents', (done) => {
     const store = createStore(combineReducers({
       map: MapReducer,
     }), applyMiddleware(thunkMiddleware));
@@ -47,36 +47,41 @@ describe('Map component context documents', () => {
       ],
     };
     store.dispatch(MapActions.setContext({json: wmsJson}));
-    let layers = map.map.getLayers().getArray();
-    expect(layers[0]).toBeInstanceOf(TileLayer);
-    expect(layers[0].getSource()).toBeInstanceOf(TileWMSSource);
-    const osmJson = {
-      version: 8,
-      name: 'osm',
-      center: [-98.78906130124426, 37.92686191312036],
-      zoom: 4,
-      sources: {
-        osm: {
-          type: 'raster',
-          attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors.',
-          tileSize: 256,
-          tiles: [
-            'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
-          ],
+    window.setTimeout(() => {
+      let layers = map.map.getLayers().getArray();
+      expect(layers[0]).toBeInstanceOf(TileLayer);
+      expect(layers[0].getSource()).toBeInstanceOf(TileWMSSource);
+      const osmJson = {
+        version: 8,
+        name: 'osm',
+        center: [-98.78906130124426, 37.92686191312036],
+        zoom: 4,
+        sources: {
+          osm: {
+            type: 'raster',
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors.',
+            tileSize: 256,
+            tiles: [
+              'https://a.tile.openstreetmap.org/{z}/{x}/{y}.png',
+              'https://b.tile.openstreetmap.org/{z}/{x}/{y}.png',
+              'https://c.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            ],
+          },
         },
-      },
-      layers: [
-        {
-          id: 'osm',
-          source: 'osm',
-        },
-      ],
-    };
-    store.dispatch(MapActions.setContext({json: osmJson}));
-    layers = map.map.getLayers().getArray();
-    expect(layers[0]).toBeInstanceOf(TileLayer);
-    expect(layers[0].getSource()).toBeInstanceOf(XYZSource);
+        layers: [
+          {
+            id: 'osm',
+            source: 'osm',
+          },
+        ],
+      };
+      store.dispatch(MapActions.setContext({json: osmJson}));
+      window.setTimeout(() => {
+        layers = map.map.getLayers().getArray();
+        expect(layers[0]).toBeInstanceOf(TileLayer);
+        expect(layers[0].getSource()).toBeInstanceOf(XYZSource);
+        done();
+      }, 0);
+    }, 0);
   });
 });

--- a/__tests__/components/map-geojson-source.test.js
+++ b/__tests__/components/map-geojson-source.test.js
@@ -50,15 +50,17 @@ describe('tests for the geojson-type map sources', () => {
       data,
     }));
 
-    // check to see if the map source is now defined.
-    expect(map.sources[src_name]).not.toBe(undefined);
+    window.setTimeout(() => {
+      // check to see if the map source is now defined.
+      expect(map.sources[src_name]).not.toBe(undefined);
 
-    // check the feature count matches.
-    setTimeout(() => {
-      const src = map.sources[src_name];
-      expect(src.getFeatures().length).toBe(nFeatures);
-      done();
-    }, 200);
+      // check the feature count matches.
+      setTimeout(() => {
+        const src = map.sources[src_name];
+        expect(src.getFeatures().length).toBe(nFeatures);
+        done();
+      }, 200);
+    }, 0);
   }
 
   it('handles undefined data', (done) => {

--- a/__tests__/components/map-sprite-animate.test.js
+++ b/__tests__/components/map-sprite-animate.test.js
@@ -36,7 +36,7 @@ describe('tests for the sprite animation map layers', () => {
     map = wrapper.instance().getWrappedInstance();
   });
 
-  it('sets the correct style function', () => {
+  it('sets the correct style function', (done) => {
     // add source
     store.dispatch(MapActions.addSource('points', {
       type: 'geojson',
@@ -69,17 +69,20 @@ describe('tests for the sprite animation map layers', () => {
       source: 'points',
       type: 'symbol',
     }));
-    const olLayer = map.layers['points-helicopters'];
-    const styleFn = olLayer.getStyle();
-    const style = styleFn(new Feature());
-    expect(style.getImage()).toBeInstanceOf(SdkSpriteStyle);
-    spyOn(style.getImage(), 'update');
-    // postcompose should trigger update
-    map.map.dispatchEvent({type: 'postcompose'});
-    expect(style.getImage().update).toHaveBeenCalled();
+    window.setTimeout(() => {
+      const olLayer = map.layers['points-helicopters'];
+      const styleFn = olLayer.getStyle();
+      const style = styleFn(new Feature());
+      expect(style.getImage()).toBeInstanceOf(SdkSpriteStyle);
+      spyOn(style.getImage(), 'update');
+      // postcompose should trigger update
+      map.map.dispatchEvent({type: 'postcompose'});
+      expect(style.getImage().update).toHaveBeenCalled();
+      done();
+    }, 0);
   });
 
-  it('sets the correct style function and filter', () => {
+  it('sets the correct style function and filter', (done) => {
     // add source
     store.dispatch(MapActions.addSource('points', {
       type: 'geojson',
@@ -111,12 +114,15 @@ describe('tests for the sprite animation map layers', () => {
       source: 'points',
       type: 'symbol',
     }));
-    const olLayer = map.layers['points-helicopters'];
-    const styleFn = olLayer.getStyle();
-    let style = styleFn(new Feature({visible: 1}));
-    expect(style).toEqual(null);
-    style = styleFn(new Feature({visible: 0}));
-    expect(style.getImage()).toBeInstanceOf(SdkSpriteStyle);
+    window.setTimeout(() => {
+      const olLayer = map.layers['points-helicopters'];
+      const styleFn = olLayer.getStyle();
+      let style = styleFn(new Feature({visible: 1}));
+      expect(style).toEqual(null);
+      style = styleFn(new Feature({visible: 0}));
+      expect(style.getImage()).toBeInstanceOf(SdkSpriteStyle);
+      done();
+    }, 0);
   });
 
 });

--- a/__tests__/components/map-time.test.js
+++ b/__tests__/components/map-time.test.js
@@ -13,7 +13,7 @@ import * as MapActions from '../../src/actions/map';
 configure({adapter: new Adapter()});
 
 describe('Map component time tests', () => {
-  it('should correctly reload WMS source that is time enabled', () => {
+  it('should correctly reload WMS source that is time enabled', (done) => {
     const store = createStore(combineReducers({
       map: MapReducer,
     }));
@@ -35,16 +35,19 @@ describe('Map component time tests', () => {
     }));
     store.dispatch(MapActions.setLayerTime('nexrad', '1995-01-01/2017-12-31/PT5M'));
 
-    let layers = map.map.getLayers().getArray();
-    const source = layers[0].getSource();
-    let params = source.getParams();
-    expect(params.TIME).toBeUndefined();
-    store.dispatch(MapActions.setMapTime('2006-06-23T03:10:00Z'));
-    params = source.getParams();
-    expect(params.TIME).toBe('2006-06-23T03:10:00Z');
+    window.setTimeout(() => {
+      let layers = map.map.getLayers().getArray();
+      const source = layers[0].getSource();
+      let params = source.getParams();
+      expect(params.TIME).toBeUndefined();
+      store.dispatch(MapActions.setMapTime('2006-06-23T03:10:00Z'));
+      params = source.getParams();
+      expect(params.TIME).toBe('2006-06-23T03:10:00Z');
+      done();
+    }, 0);
   });
 
-  it('should correctly set TIME param if source added after setMapTime', () => {
+  it('should correctly set TIME param if source added after setMapTime', (done) => {
     const store = createStore(combineReducers({
       map: MapReducer,
     }));
@@ -67,10 +70,13 @@ describe('Map component time tests', () => {
     }));
     store.dispatch(MapActions.setLayerTime('nexrad', '1995-01-01/2017-12-31/PT5M'));
 
-    let layers = map.map.getLayers().getArray();
-    const source = layers[0].getSource();
-    const params = source.getParams();
-    expect(params.TIME).toBe('2006-06-23T03:10:00Z');
+    window.setTimeout(() => {
+      let layers = map.map.getLayers().getArray();
+      const source = layers[0].getSource();
+      const params = source.getParams();
+      expect(params.TIME).toBe('2006-06-23T03:10:00Z');
+      done();
+    }, 0);
   });
 
   it('should correctly filter a vector source that is time enabled', () => {

--- a/__tests__/components/map.test.js
+++ b/__tests__/components/map.test.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import {shallow, mount, configure} from 'enzyme';
 import nock from 'nock';
-import  Adapter from 'enzyme-adapter-react-16';
+import Adapter from 'enzyme-adapter-react-16';
 
 import olMap from 'ol/pluggablemap';
 import olView from 'ol/view';
@@ -35,6 +35,11 @@ import * as PrintActions from '../../src/actions/print';
 configure({adapter: new Adapter()});
 
 describe('Map component', () => {
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   it('should render without throwing an error', () => {
     const wrapper = shallow(<Map />);
     expect(wrapper.find('.sdk-map').length).toBe(1);
@@ -45,7 +50,21 @@ describe('Map component', () => {
     expect(wrapper.find('.foo').length).toBe(1);
   });
 
-  it('should create a map', () => {
+  it('should create a map', (done) => {
+
+    // eslint-disable-next-line
+    const response = {
+      'maxzoom': 16,
+      'minzoom': 4,
+      'tiles': [
+        'https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=foo',
+        'https://b.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=foo'
+      ]
+    };
+    nock('https://api.mapbox.com')
+      .get('/v4/mapbox.mapbox-streets-v7.json?access_token=foo')
+      .reply(200, response);
+
     const sources = {
       osm: {
         type: 'raster',
@@ -77,7 +96,7 @@ describe('Map component', () => {
       },
       mvt: {
         type: 'vector',
-        url: 'https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf?access_token=test_key',
+        tiles: ['https://{a-d}.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6/{z}/{x}/{y}.vector.pbf?access_token=test_key'],
       },
       mapbox: {
         url: 'mapbox://mapbox.mapbox-streets-v7',
@@ -156,38 +175,40 @@ describe('Map component', () => {
     const map = wrapper.instance().map;
     expect(map).toBeDefined();
     expect(map).toBeInstanceOf(olMap);
-    expect(map.getLayers().item(0)).toBeInstanceOf(TileLayer);
-    expect(map.getLayers().item(1)).toBeInstanceOf(TileLayer);
-    expect(map.getLayers().item(1).getSource()).toBeInstanceOf(TileWMSSource);
-    const tileLoadFunction = map.getLayers().item(6).getSource().getTileLoadFunction();
-    const tileCoord = [0, 0, 0];
-    const state = TileState.IDLE;
-    const src = 'https://www.example.com/foo?BBOX={bbox-epsg-3857}';
-    const tile = new ImageTile(tileCoord, state, src, null, tileLoadFunction);
-    tileLoadFunction(tile, src);
-    // bbox substituted
-    expect(tile.getImage().src).toBe('https://www.example.com/foo?BBOX=-20037508.342789244,20037508.342789244,20037508.342789244,60112525.02836773');
-    // REQUEST param cleared
-    expect(map.getLayers().item(1).getSource().getParams().REQUEST).toBe(undefined);
-    expect(map.getLayers().item(2)).toBeInstanceOf(VectorLayer);
-    expect(map.getLayers().item(3)).toBeInstanceOf(VectorTileLayer);
-    expect(map.getLayers().item(3).getZIndex()).toBe(3);
-    const expected = `https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=${apiKey}`;
-    expect(map.getLayers().item(4).getSource().getUrls()[0]).toBe(expected);
-    expect(map.getLayers().item(4).getSource().getUrls()[1]).toBe(expected.replace('a.', 'b.'));
-    expect(map.getLayers().item(4).getSource().getUrls()[2]).toBe(expected.replace('a.', 'c.'));
-    expect(map.getLayers().item(4).getSource().getUrls()[3]).toBe(expected.replace('a.', 'd.'));
-    let tileUrlFunction = map.getLayers().item(7).getSource().getTileUrlFunction();
-    expect(tileUrlFunction(tileCoord)).toBe('http://www.example.com/tms/0/0/1.png');
-    tileUrlFunction = map.getLayers().item(8).getSource().getTileUrlFunction();
-    expect(tileUrlFunction(tileCoord)).toBe('http://www.example.com/0/0/-1.png');
-    // move the map.
-    wrapper.setProps({
-      zoom: 4,
-    });
-    spyOn(map, 'setTarget');
-    wrapper.unmount();
-    expect(map.setTarget).toHaveBeenCalledWith(null);
+    window.setTimeout(() => {
+      expect(map.getLayers().item(0)).toBeInstanceOf(TileLayer);
+      expect(map.getLayers().item(1)).toBeInstanceOf(TileLayer);
+      expect(map.getLayers().item(1).getSource()).toBeInstanceOf(TileWMSSource);
+      const tileLoadFunction = map.getLayers().item(6).getSource().getTileLoadFunction();
+      const tileCoord = [0, 0, 0];
+      const state = TileState.IDLE;
+      const src = 'https://www.example.com/foo?BBOX={bbox-epsg-3857}';
+      const tile = new ImageTile(tileCoord, state, src, null, tileLoadFunction);
+      tileLoadFunction(tile, src);
+      // bbox substituted
+      expect(tile.getImage().src).toBe('https://www.example.com/foo?BBOX=-20037508.342789244,20037508.342789244,20037508.342789244,60112525.02836773');
+      // REQUEST param cleared
+      expect(map.getLayers().item(1).getSource().getParams().REQUEST).toBe(undefined);
+      expect(map.getLayers().item(2)).toBeInstanceOf(VectorLayer);
+      expect(map.getLayers().item(3)).toBeInstanceOf(VectorTileLayer);
+      expect(map.getLayers().item(3).getZIndex()).toBe(3);
+      const expected = `https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=${apiKey}`;
+      expect(map.getLayers().item(4).getSource().getUrls()[0]).toBe(expected);
+      expect(map.getLayers().item(4).getSource().getUrls()[1]).toBe(expected.replace('a.', 'b.'));
+      expect(map.getLayers().item(4).getMaxResolution()).toBe(4891.96981025128);
+      let tileUrlFunction = map.getLayers().item(7).getSource().getTileUrlFunction();
+      expect(tileUrlFunction(tileCoord)).toBe('http://www.example.com/tms/0/0/1.png');
+      tileUrlFunction = map.getLayers().item(8).getSource().getTileUrlFunction();
+      expect(tileUrlFunction(tileCoord)).toBe('http://www.example.com/0/0/-1.png');
+      // move the map.
+      wrapper.setProps({
+        zoom: 4,
+      });
+      spyOn(map, 'setTarget');
+      wrapper.unmount();
+      expect(map.setTarget).toHaveBeenCalledWith(null);
+      done();
+    }, 200);
   });
 
   it('should ignore unknown types', () => {
@@ -213,7 +234,7 @@ describe('Map component', () => {
     expect(map.getLayers().getLength()).toBe(0);
   });
 
-  it('should create a static image', () => {
+  it('should create a static image', (done) => {
     const sources = {
       overlay: {
         type: 'image',
@@ -242,14 +263,30 @@ describe('Map component', () => {
     };
     const wrapper = mount(<Map map={{center, zoom, sources, layers, metadata}} />);
     const map = wrapper.instance().map;
-    const layer = map.getLayers().item(0);
-    expect(layer).toBeInstanceOf(ImageLayer);
-    expect(layer.getOpacity()).toEqual(layers[0].paint['raster-opacity']);
-    const source = layer.getSource();
-    expect(source).toBeInstanceOf(ImageStaticSource);
+    window.setTimeout(() => {
+      const layer = map.getLayers().item(0);
+      expect(layer).toBeInstanceOf(ImageLayer);
+      expect(layer.getOpacity()).toEqual(layers[0].paint['raster-opacity']);
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(ImageStaticSource);
+      done();
+    }, 0);
   });
 
-  it('should create mvt groups', () => {
+  it('should create mvt groups', (done) => {
+    // eslint-disable-next-line
+    const response = {
+      'maxzoom': 16,
+      'minzoom': 0,
+      'tiles': [
+        'https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=foo',
+        'https://b.tiles.mapbox.com/v4/mapbox.mapbox-streets-v7/{z}/{x}/{y}.vector.pbf?access_token=foo'
+      ]
+    };
+    nock('https://api.mapbox.com')
+      .get('/v4/mapbox.mapbox-streets-v7.json?access_token=foo')
+      .reply(200, response);
+
     const sources = {
       mapbox: {
         url: 'mapbox://mapbox.mapbox-streets-v7',
@@ -316,22 +353,26 @@ describe('Map component', () => {
       'bnd:source-version': 0,
       'bnd:layer-version': 0,
     };
-    const wrapper = mount(<Map map={{center, zoom, sources, layers, metadata}} />);
+    const apiKey = 'foo';
+    const wrapper = mount(<Map mapbox={{accessToken: apiKey}} map={{center, zoom, sources, layers, metadata}} />);
     const instance = wrapper.instance();
     const map = instance.map;
-    expect(map.getLayers().getLength()).toBe(1); // 1 layer created
-    const layer = map.getLayers().item(0);
-    expect(layer).toBeInstanceOf(VectorTileLayer);
-    const source = layer.getSource();
-    expect(source).toBeInstanceOf(VectorTileSource);
-    expect(layer.get('name')).toBe('mapbox-landuse_overlay_national_park,landuse_park,water_label');
-    expect(instance.layers[layer.get('name')]).toBe(layer);
-    spyOn(layer, 'setSource');
-    instance.updateLayerSource('mapbox');
-    expect(layer.setSource).toHaveBeenCalled();
+    window.setTimeout(() => {
+      expect(map.getLayers().getLength()).toBe(1); // 1 layer created
+      const layer = map.getLayers().item(0);
+      expect(layer).toBeInstanceOf(VectorTileLayer);
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(VectorTileSource);
+      expect(layer.get('name')).toBe('mapbox-landuse_overlay_national_park,landuse_park,water_label');
+      expect(instance.layers[layer.get('name')]).toBe(layer);
+      spyOn(layer, 'setSource');
+      instance.updateLayerSource('mapbox');
+      expect(layer.setSource).toHaveBeenCalled();
+      done();
+    }, 200);
   });
 
-  it('should create a raster tilejson', () => {
+  it('should create a raster tilejson', (done) => {
     const sources = {
       tilejson: {
         type: 'raster',
@@ -350,14 +391,17 @@ describe('Map component', () => {
     const center = [0, 0];
     const zoom = 2;
     const wrapper = mount(<Map map={{center, zoom, sources, layers, metadata}} />);
-    const map = wrapper.instance().map;
-    const layer = map.getLayers().item(0);
-    expect(layer).toBeInstanceOf(TileLayer);
-    const source = layer.getSource();
-    expect(source).toBeInstanceOf(TileJSONSource);
+    window.setTimeout(() => {
+      const map = wrapper.instance().map;
+      const layer = map.getLayers().item(0);
+      expect(layer).toBeInstanceOf(TileLayer);
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(TileJSONSource);
+      done();
+    });
   });
 
-  it('should handle visibility changes', () => {
+  it('should handle visibility changes', (done) => {
     const sources = {
       tilejson: {
         type: 'raster',
@@ -377,30 +421,35 @@ describe('Map component', () => {
     const zoom = 2;
     const wrapper = mount(<Map map={{center, zoom, sources, layers, metadata}} />);
 
-    const instance = wrapper.instance();
-    const map = instance.map;
-    const layer = map.getLayers().item(0);
-    expect(layer.getVisible()).toBe(true);
-    const nextProps = {
-      map: {
-        center,
-        zoom,
-        metadata: {
-          'bnd:source-version': 0,
-          'bnd:layer-version': 1,
-        },
-        sources,
-        layers: [{
-          id: 'tilejson-layer',
-          source: 'tilejson',
-          layout: {
-            visibility: 'none',
+    window.setTimeout(() => {
+      const instance = wrapper.instance();
+      const map = instance.map;
+      const layer = map.getLayers().item(0);
+      expect(layer.getVisible()).toBe(true);
+      const nextProps = {
+        map: {
+          center,
+          zoom,
+          metadata: {
+            'bnd:source-version': 0,
+            'bnd:layer-version': 1,
           },
-        }],
-      },
-    };
-    instance.shouldComponentUpdate.call(instance, nextProps);
-    expect(layer.getVisible()).toBe(false);
+          sources,
+          layers: [{
+            id: 'tilejson-layer',
+            source: 'tilejson',
+            layout: {
+              visibility: 'none',
+            },
+          }],
+        },
+      };
+      instance.shouldComponentUpdate.call(instance, nextProps);
+      window.setTimeout(() => {
+        expect(layer.getVisible()).toBe(false);
+        done();
+      }, 0);
+    }, 0);
   });
 
   it('should handle undefined center, zoom and bearing in constructor', () => {
@@ -477,7 +526,7 @@ describe('Map component', () => {
     expect(view.getCenter()).toBe(centerWGS84);
   });
 
-  it('should handle layout changes', () => {
+  it('should handle layout changes', (done) => {
     const sources = {
       geojson: {
         type: 'geojson',
@@ -511,15 +560,18 @@ describe('Map component', () => {
     const wrapper = mount(<Map map={{center, zoom, sources, layers, metadata}} />);
     const instance = wrapper.instance();
 
-    const map = instance.map;
-    const layer = map.getLayers().item(0);
-    const ol_style = layer.getStyle();
+    window.setTimeout(() => {
+      const map = instance.map;
+      const layer = map.getLayers().item(0);
+      const ol_style = layer.getStyle();
 
-    // test that the style has been set to something
-    expect(typeof ol_style).toEqual('function');
+      // test that the style has been set to something
+      expect(typeof ol_style).toEqual('function');
+      done();
+    }, 0);
   });
 
-  it('handles updates to geojson source', () => {
+  it('handles updates to geojson source', (done) => {
     const sources = {
       drone: {
         type: 'geojson',
@@ -562,19 +614,22 @@ describe('Map component', () => {
       },
     };
     let error = false;
-    try {
-      instance.shouldComponentUpdate.call(instance, nextProps);
-    } catch (e) {
-      error = true;
-    }
-    expect(error).toBe(false);
+    window.setTimeout(() => {
+      try {
+        instance.shouldComponentUpdate.call(instance, nextProps);
+      } catch (e) {
+        error = true;
+      }
+      expect(error).toBe(false);
+      done();
+    }, 0);
   });
 
-  it('handles updates to source and layer min/maxzoom values', () => {
+  it('handles updates to source and layer min/maxzoom values', (done) => {
     const sources = {
       tilejson: {
         type: 'raster',
-        url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
+        url: 'https://api.mapbox.com/v3/mapbox.geography-class.json?secure',
       },
     };
     const layers = [{
@@ -591,79 +646,85 @@ describe('Map component', () => {
     const zoom = 2;
     const wrapper = mount(<Map map={{center, zoom, sources, layers, metadata}} />);
 
-    const instance = wrapper.instance();
-    const map = instance.map;
-    const view = map.getView();
-    const layer = map.getLayers().item(0);
+    window.setTimeout(() => {
+      const instance = wrapper.instance();
+      const map = instance.map;
+      const view = map.getView();
+      const layer = map.getLayers().item(0);
 
-    // min/max zoom values defined on source only
-    let nextProps = {
-      map: {
-        center,
-        zoom,
-        metadata: {
-          'bnd:source-version': 1,
-          'bnd:layer-version': 2,
-        },
-        sources: {
-          tilejson: {
-            type: 'raster',
-            url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
-            minzoom: 4,
-            maxzoom: 8,
+      // min/max zoom values defined on source only
+      let nextProps = {
+        map: {
+          center,
+          zoom,
+          metadata: {
+            'bnd:source-version': 1,
+            'bnd:layer-version': 2,
           },
-        },
-        layers: [{
-          id: 'tilejson-layer',
-          source: 'tilejson',
-        }],
-      },
-    };
-    instance.shouldComponentUpdate.call(instance, nextProps);
-    let max_rez = view.constrainResolution(
-      view.getMaxResolution(), nextProps.map.sources.tilejson.maxzoom - view.getMinZoom());
-    expect(layer.getMaxResolution()).toEqual(max_rez);
-
-    let min_rez = view.constrainResolution(
-      view.getMaxResolution(), nextProps.map.sources.tilejson.minzoom - view.getMinZoom());
-    expect(layer.getMinResolution()).toEqual(min_rez);
-
-    // min.max zoom values defined on both source and layer def
-    nextProps = {
-      map: {
-        center,
-        zoom,
-        metadata: {
-          'bnd:source-version': 2,
-          'bnd:layer-version': 3,
-        },
-        sources: {
-          tilejson: {
-            type: 'raster',
-            url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
-            minzoom: 1,
-            maxzoom: 7,
+          sources: {
+            tilejson: {
+              type: 'raster',
+              url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
+              minzoom: 4,
+              maxzoom: 8,
+            },
           },
+          layers: [{
+            id: 'tilejson-layer',
+            source: 'tilejson',
+          }],
         },
-        layers: [{
-          id: 'tilejson-layer',
-          source: 'tilejson',
-          minzoom: 2,
-          maxzoom: 9,
-        }],
-      },
-    };
-    instance.shouldComponentUpdate.call(instance, nextProps);
-    // the layer minzoom will be handled in the style and *not* on the layer itself.
-    max_rez = view.constrainResolution(
-      view.getMaxResolution(), nextProps.map.sources.tilejson.maxzoom - view.getMinZoom());
-    expect(layer.getMaxResolution()).toEqual(max_rez);
-    min_rez = view.constrainResolution(
-      view.getMinResolution(), nextProps.map.sources.tilejson.minzoom - view.getMaxZoom());
-    expect(layer.getMinResolution()).toEqual(min_rez);
+      };
+      instance.shouldComponentUpdate.call(instance, nextProps);
+      window.setTimeout(() => {
+        let max_rez = view.constrainResolution(
+          view.getMaxResolution(), nextProps.map.sources.tilejson.maxzoom - view.getMinZoom());
+        expect(layer.getMaxResolution()).toEqual(max_rez);
+        let min_rez = view.constrainResolution(
+          view.getMaxResolution(), nextProps.map.sources.tilejson.minzoom - view.getMinZoom());
+        expect(layer.getMinResolution()).toEqual(min_rez);
+
+        // min.max zoom values defined on both source and layer def
+        nextProps = {
+          map: {
+            center,
+            zoom,
+            metadata: {
+              'bnd:source-version': 2,
+              'bnd:layer-version': 3,
+            },
+            sources: {
+              tilejson: {
+                type: 'raster',
+                url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
+                minzoom: 1,
+                maxzoom: 7,
+              },
+            },
+            layers: [{
+              id: 'tilejson-layer',
+              source: 'tilejson',
+              minzoom: 2,
+              maxzoom: 9,
+            }],
+          },
+        };
+        instance.shouldComponentUpdate.call(instance, nextProps);
+        window.setTimeout(() => {
+          // the layer minzoom will be handled in the style and *not* on the layer itself.
+          max_rez = view.constrainResolution(
+            view.getMaxResolution(), nextProps.map.sources.tilejson.maxzoom - view.getMinZoom());
+          expect(layer.getMaxResolution()).toEqual(max_rez);
+          min_rez = view.constrainResolution(
+            view.getMinResolution(), nextProps.map.sources.tilejson.minzoom - view.getMaxZoom());
+          expect(layer.getMinResolution()).toEqual(min_rez);
+          done();
+        }, 0);
+      }, 0);
+    }, 0);
   });
 
-  it('should handle layer removal and re-adding', () => {
+  it('should handle layer removal and re-adding', (done) => {
     const sources = {
       tilejson: {
         type: 'raster',
@@ -681,40 +742,47 @@ describe('Map component', () => {
       'bnd:layer-version': 0,
     };
     const wrapper = mount(<Map map={{center, zoom, sources, layers, metadata}} />);
-    const instance = wrapper.instance();
-    const map = instance.map;
-    expect(map.getLayers().item(0)).not.toBe(undefined);
-    let nextProps = {
-      map: {
-        center,
-        zoom,
-        metadata: {
-          'bnd:source-version': 0,
-          'bnd:layer-version': 1,
+    window.setTimeout(() => {
+      const instance = wrapper.instance();
+      const map = instance.map;
+      expect(map.getLayers().item(0)).not.toBe(undefined);
+      let nextProps = {
+        map: {
+          center,
+          zoom,
+          metadata: {
+            'bnd:source-version': 0,
+            'bnd:layer-version': 1,
+          },
+          sources,
+          layers: [],
         },
-        sources,
-        layers: [],
-      },
-    };
-    instance.shouldComponentUpdate.call(instance, nextProps);
-    expect(map.getLayers().getLength()).toBe(0);
-    nextProps = {
-      map: {
-        center,
-        zoom,
-        metadata: {
-          'bnd:source-version': 0,
-          'bnd:layer-version': 2,
-        },
-        sources,
-        layers,
-      },
-    };
-    instance.shouldComponentUpdate.call(instance, nextProps);
-    expect(map.getLayers().getLength()).toBe(1);
+      };
+      instance.shouldComponentUpdate.call(instance, nextProps);
+      window.setTimeout(() => {
+        expect(map.getLayers().getLength()).toBe(0);
+        nextProps = {
+          map: {
+            center,
+            zoom,
+            metadata: {
+              'bnd:source-version': 0,
+              'bnd:layer-version': 2,
+            },
+            sources,
+            layers,
+          },
+        };
+        instance.shouldComponentUpdate.call(instance, nextProps);
+        window.setTimeout(() => {
+          expect(map.getLayers().getLength()).toBe(1);
+          done();
+        }, 0);
+      }, 0);
+    }, 0);
   });
 
-  it('removes sources version definition when excluded from map spec', () => {
+  it('removes sources version definition when excluded from map spec', (done) => {
     const sources = {
       tilejson: {
         type: 'raster',
@@ -733,17 +801,22 @@ describe('Map component', () => {
     };
     const wrapper = mount(<Map map={{sources, layers, center, zoom, metadata}} />);
     const instance = wrapper.instance();
-    expect(instance.sourcesVersion).toEqual(0);
-    const nextProps = {
-      map: {
-        center,
-        zoom,
-        sources,
-        layers: [],
-      },
-    };
-    instance.shouldComponentUpdate.call(instance, nextProps);
-    expect(instance.sourcesVersion).toEqual(undefined);
+    window.setTimeout(() => {
+      expect(instance.sourcesVersion).toEqual(0);
+      const nextProps = {
+        map: {
+          center,
+          zoom,
+          sources,
+          layers: [],
+        },
+      };
+      instance.shouldComponentUpdate.call(instance, nextProps);
+      window.setTimeout(() => {
+        expect(instance.sourcesVersion).toEqual(undefined);
+        done();
+      }, 0);
+    }, 0);
   });
 
   it('should create a connected map', () => {
@@ -833,7 +906,7 @@ describe('Map component', () => {
     expect(sdk_map.map.updateSize).toHaveBeenCalled();
   });
 
-  it('should update the source url', () => {
+  it('should update the source url', (done) => {
     const store = createStore(combineReducers({
       map: MapReducer,
     }));
@@ -850,16 +923,20 @@ describe('Map component', () => {
 
     const wrapper = mount(<ConnectedMap store={store} />);
     const sdk_map = wrapper.instance().getWrappedInstance();
-
-    let source = sdk_map.sources['foo'];
-    expect(source.getParams()['SALT']).toBeUndefined();
-    store.dispatch(MapActions.updateSource('foo', {
-      type: 'raster',
-      tileSize: 256,
-      tiles: [getMapUrl + '&SALT=0.556643'],
-    }));
-    source = sdk_map.sources['foo'];
-    expect(source.getParams()['SALT']).toEqual('0.556643');
+    window.setTimeout(() => {
+      let source = sdk_map.sources['foo'];
+      expect(source.getParams()['SALT']).toBeUndefined();
+      store.dispatch(MapActions.updateSource('foo', {
+        type: 'raster',
+        tileSize: 256,
+        tiles: [getMapUrl + '&SALT=0.556643'],
+      }));
+      window.setTimeout(() => {
+        source = sdk_map.sources['foo'];
+        expect(source.getParams()['SALT']).toEqual('0.556643');
+        done();
+      }, 0);
+    }, 0);
   });
 
   it('should trigger the setRotation callback', () => {
@@ -1031,7 +1108,7 @@ describe('Map component', () => {
       url: 'mapbox://mapbox.satellite',
     };
     const url = getTileJSONUrl(glSource, apiKey);
-    expect(url).toEqual('https://a.tiles.mapbox.com/v4/mapbox.satellite.json?access_token=foo');
+    expect(url).toEqual('https://api.mapbox.com/v4/mapbox.satellite.json?access_token=foo');
   });
 
   it('should handle getFakeStyle', () => {
@@ -1107,12 +1184,6 @@ describe('Map component', () => {
     });
 
     expect(sdk_map.handleAsyncGetFeatureInfo).toHaveBeenCalled();
-  });
-});
-
-describe('Map component async', () => {
-  afterEach(() => {
-    nock.cleanAll();
   });
 
   // removed set spriteData tests as they are now handled in ol-mapbox-style

--- a/__tests__/components/map.test.js
+++ b/__tests__/components/map.test.js
@@ -842,6 +842,32 @@ describe('Map component', () => {
     expect(store.getState().mapinfo.size).toEqual([100, 200]);
   });
 
+  it('should change layer visibility', (done) => {
+    const store = createStore(combineReducers({
+      map: MapReducer,
+    }));
+
+    const wrapper = mount(<ConnectedMap store={store} />);
+    const sdk_map = wrapper.instance().getWrappedInstance();
+
+    store.dispatch(MapActions.addOsmSource('foo'));
+    store.dispatch(MapActions.addLayer({
+      id: 'foo',
+      source: 'foo',
+    }));
+
+    let layer;
+    window.setTimeout(function() {
+      layer = sdk_map.map.getLayers().item(0);
+      expect(layer.getVisible()).toBe(true);
+      store.dispatch(MapActions.setLayerVisibility('foo', 'none'));
+      window.setTimeout(function() {
+        layer = sdk_map.map.getLayers().item(0);
+        expect(layer.getVisible()).toBe(false);
+        done();
+      }, 0);
+    }, 0);
+  });
 
   it('should trigger the setView callback', () => {
     const store = createStore(combineReducers({

--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -511,15 +511,13 @@ export function addWmsSource(sourceId, serverUrl, layerName, options = {}) {
   if (options.asVector !== false) {
     return addSource(sourceId, {
       type: 'vector',
-      url: url_template,
+      tiles: [url_template],
     });
   } else {
     return addSource(sourceId, {
       type: 'raster',
       tileSize: tile_size,
-      tiles: [
-        url_template,
-      ],
+      tiles: [url_template],
     });
   }
 }
@@ -571,7 +569,7 @@ export function addTmsSource(sourceId, serverUrl, layerName, options = {}) {
 
   return addSource(sourceId, {
     type: 'vector',
-    url,
+    tiles: [url],
   });
 }
 

--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -266,7 +266,7 @@ export function removeFeatures(sourceName, filter) {
 /** Change the visibility of a given layer in the map state.
  *
  *  @param {string} layerId String id for the layer.
- *  @param {boolean} visibility Should the layer be visible?
+ *  @param {string} visibility 'none' or 'visible'.
  *
  *  @returns {Object} Action object to pass to reducer.
  */

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -98,7 +98,7 @@ const GEOJSON_FORMAT = new GeoJsonFormat();
 const ESRIJSON_FORMAT = new EsriJsonFormat();
 const WGS84_SPHERE = new Sphere(6378137);
 const MAPBOX_PROTOCOL = 'mapbox://';
-const MAPBOX_HOST = 'tiles.mapbox.com/v4';
+const MAPBOX_HOST = 'api.mapbox.com/v4';
 const BBOX_STRING = '{bbox-epsg-3857}';
 
 plugins.register(PluginType.MAP_RENDERER, MapRenderer);
@@ -128,60 +128,63 @@ function getVersion(obj, key) {
  * @returns {Object} Configured OpenLayers TileWMSSource or XyzSource.
  */
 function configureTileSource(glSource, mapProjection, time) {
-  const tile_url = glSource.tiles[0];
-  const commonProps = {
-    attributions: glSource.attribution,
-    minZoom: glSource.minzoom,
-    maxZoom: 'maxzoom' in glSource ? glSource.maxzoom : 22,
-    tileSize: glSource.tileSize || 512,
-    crossOrigin: 'crossOrigin' in glSource ? glSource.crossOrigin : 'anonymous',
-    projection: mapProjection,
-  };
-  // check to see if the url is a wms request.
-  if (tile_url.toUpperCase().indexOf('SERVICE=WMS') >= 0) {
-    const urlParts = glSource.tiles[0].split('?');
-    const params = parseQueryString(urlParts[1]);
-    const keys = Object.keys(params);
-    for (let i = 0, ii = keys.length; i < ii; ++i) {
-      if (keys[i].toUpperCase() === 'REQUEST') {
-        delete params[keys[i]];
+  return new Promise((resolve) => {
+    const tile_url = glSource.tiles[0];
+    const commonProps = {
+      attributions: glSource.attribution,
+      minZoom: glSource.minzoom,
+      maxZoom: 'maxzoom' in glSource ? glSource.maxzoom : 22,
+      tileSize: glSource.tileSize || 512,
+      crossOrigin: 'crossOrigin' in glSource ? glSource.crossOrigin : 'anonymous',
+      projection: mapProjection,
+    };
+    // check to see if the url is a wms request.
+    if (tile_url.toUpperCase().indexOf('SERVICE=WMS') >= 0) {
+      const urlParts = glSource.tiles[0].split('?');
+      const params = parseQueryString(urlParts[1]);
+      const keys = Object.keys(params);
+      for (let i = 0, ii = keys.length; i < ii; ++i) {
+        if (keys[i].toUpperCase() === 'REQUEST') {
+          delete params[keys[i]];
+        }
       }
+      if (time) {
+        params.TIME = time;
+      }
+      resolve(new TileWMSSource(Object.assign({
+        url: urlParts[0],
+        params,
+      }, commonProps)));
+    } else {
+      const source = new XyzSource(Object.assign({
+        urls: glSource.tiles,
+      }, commonProps));
+      source.setTileLoadFunction((tile, src) => {
+        // copy the src string.
+        let img_src = src.slice();
+        if (src.indexOf(BBOX_STRING) !== -1) {
+          const bbox = source.getTileGrid().getTileCoordExtent(tile.getTileCoord());
+          img_src = src.replace(BBOX_STRING, bbox.toString());
+        }
+        // disabled the linter below as this is how
+        //  OpenLayers documents this operation.
+        // eslint-disable-next-line
+        tile.getImage().src = img_src;
+      });
+      if (glSource.scheme === 'tms') {
+        source.setTileUrlFunction((tileCoord, pixelRatio, projection) => {
+          const min = 0;
+          const max = glSource.tiles.length - 1;
+          const idx = Math.floor(Math.random() * (max - min + 1)) + min;
+          const z = tileCoord[0];
+          const x = tileCoord[1];
+          const y = tileCoord[2] + (1 << z);
+          return glSource.tiles[idx].replace('{z}', z).replace('{y}', y).replace('{x}', x);
+        });
+      }
+      resolve(source);
     }
-    if (time) {
-      params.TIME = time;
-    }
-    return new TileWMSSource(Object.assign({
-      url: urlParts[0],
-      params,
-    }, commonProps));
-  }
-  const source = new XyzSource(Object.assign({
-    urls: glSource.tiles,
-  }, commonProps));
-  source.setTileLoadFunction((tile, src) => {
-    // copy the src string.
-    let img_src = src.slice();
-    if (src.indexOf(BBOX_STRING) !== -1) {
-      const bbox = source.getTileGrid().getTileCoordExtent(tile.getTileCoord());
-      img_src = src.replace(BBOX_STRING, bbox.toString());
-    }
-    // disabled the linter below as this is how
-    //  OpenLayers documents this operation.
-    // eslint-disable-next-line
-    tile.getImage().src = img_src;
   });
-  if (glSource.scheme === 'tms') {
-    source.setTileUrlFunction((tileCoord, pixelRatio, projection) => {
-      const min = 0;
-      const max = glSource.tiles.length - 1;
-      const idx = Math.floor(Math.random() * (max - min + 1)) + min;
-      const z = tileCoord[0];
-      const x = tileCoord[1];
-      const y = tileCoord[2] + (1 << z);
-      return glSource.tiles[idx].replace('{z}', z).replace('{y}', y).replace('{x}', x);
-    });
-  }
-  return source;
 }
 
 /** Gets the url for the TileJSON source.
@@ -194,7 +197,7 @@ export function getTileJSONUrl(glSource, accessToken) {
   let url = glSource.url;
   if (url.indexOf(MAPBOX_PROTOCOL) === 0) {
     const mapid = url.replace(MAPBOX_PROTOCOL, '');
-    url = `https://a.${MAPBOX_HOST}/${mapid}.json?access_token=${accessToken}`;
+    url = `https://${MAPBOX_HOST}/${mapid}.json?access_token=${accessToken}`;
   }
   return url;
 }
@@ -207,9 +210,11 @@ export function getTileJSONUrl(glSource, accessToken) {
  * @returns {Object} Configured OpenLayers TileJSONSource.
  */
 function configureTileJSONSource(glSource, accessToken) {
-  return new TileJSON({
-    url: getTileJSONUrl(glSource, accessToken),
-    crossOrigin: 'anonymous',
+  return new Promise((resolve) => {
+    resolve(new TileJSON({
+      url: getTileJSONUrl(glSource, accessToken),
+      crossOrigin: 'anonymous',
+    }));
   });
 }
 
@@ -220,13 +225,15 @@ function configureTileJSONSource(glSource, accessToken) {
  * @returns {Object} Configured OpenLayers ImageStaticSource.
  */
 function configureImageSource(glSource) {
-  const coords = glSource.coordinates;
-  const source = new ImageStaticSource({
-    url: glSource.url,
-    imageExtent: [coords[0][0], coords[3][1], coords[1][0], coords[0][1]],
-    projection: 'EPSG:4326',
+  return new Promise((resolve) => {
+    const coords = glSource.coordinates;
+    const source = new ImageStaticSource({
+      url: glSource.url,
+      imageExtent: [coords[0][0], coords[3][1], coords[1][0], coords[0][1]],
+      projection: 'EPSG:4326',
+    });
+    resolve(source);
   });
-  return source;
 }
 
 /** Configures an OpenLayers VectorTileSource object from the provided
@@ -237,44 +244,53 @@ function configureImageSource(glSource) {
  * @returns {Object} Configured OpenLayers VectorTileSource.
  */
 function configureMvtSource(glSource, accessToken) {
-  const url = glSource.url;
-  let urls;
-  if (url.indexOf(MAPBOX_PROTOCOL) === 0) {
-    const mapid = url.replace(MAPBOX_PROTOCOL, '');
-    const suffix = 'vector.pbf';
-    const hosts = ['a', 'b', 'c', 'd'];
-    urls = [];
-    for (let i = 0, ii = hosts.length; i < ii; ++i) {
-      const host = hosts[i];
-      urls.push(`https://${host}.${MAPBOX_HOST}/${mapid}/{z}/{x}/{y}.${suffix}?access_token=${accessToken}`);
-    }
+  if (glSource.tiles) {
+    return new Promise((resolve, reject) => {
+      // predefine the source in-case since it's needed for the tile_url_fn
+      let source;
+      let tile_url_fn;
+      // check the first tile to see if we need to do BBOX subsitution
+      if (glSource.tiles[0].indexOf(BBOX_STRING) !== -1) {
+        tile_url_fn = function(urlTileCoord, pixelRatio, projection) {
+          const bbox = source.getTileGrid().getTileCoordExtent(urlTileCoord);
+          return glSource.tiles[0].replace(BBOX_STRING, bbox.toString());
+        };
+      }
+      source = new VectorTileSource({
+        urls: glSource.tiles,
+        tileGrid: TileGrid.createXYZ({
+          tileSize: 512,
+          maxZoom: 'maxzoom' in glSource ? glSource.maxzoom : 22,
+          minZoom: glSource.minzoom,
+        }),
+        attributions: glSource.attribution,
+        format: new MvtFormat(),
+        crossOrigin: 'crossOrigin' in glSource ? glSource.crossOrigin : 'anonymous',
+        tileUrlFunction: tile_url_fn,
+      });
+      resolve(source);
+    });
   } else {
-    urls = [url];
+    let url = getTileJSONUrl(glSource, accessToken);
+    return fetch(url).then((response) => {
+      if (response.ok) {
+        return response.json();
+      }
+    })
+      .then((json) => {
+        return new VectorTileSource({
+          crossOrigin: 'crossOrigin' in glSource ? glSource.crossOrigin : 'anonymous',
+          attributions: json.attribution,
+          format: new MvtFormat(),
+          tileGrid: TileGrid.createXYZ({
+            minZoom: json.minzoom,
+            maxZoom: json.maxzoom,
+            tileSize: 512
+          }),
+          urls: json.tiles,
+        });
+      });
   }
-
-  // predefine the source in-case it is needed
-  //  for the tile_url_fn
-  let source;
-
-  // check to see if the url uses bounding box or Z,X,Y
-  let tile_url_fn;
-  if (url.indexOf(BBOX_STRING) !== -1) {
-    tile_url_fn = function(urlTileCoord, pixelRatio, projection) {
-      const bbox = source.getTileGrid().getTileCoordExtent(urlTileCoord);
-      return url.replace(BBOX_STRING, bbox.toString());
-    };
-  }
-
-  source = new VectorTileSource({
-    urls,
-    tileGrid: TileGrid.createXYZ({maxZoom: 22}),
-    tilePixelRatio: 16,
-    format: new MvtFormat(),
-    crossOrigin: 'crossOrigin' in glSource ? glSource.crossOrigin : 'anonymous',
-    tileUrlFunction: tile_url_fn,
-  });
-
-  return source;
 }
 
 function getLoaderFunction(glSource, mapProjection, baseUrl) {
@@ -358,31 +374,33 @@ function updateGeojsonSource(olSource, glSource, mapView, baseUrl) {
  *  @returns {Object} ol.source.vector instance.
  */
 function configureGeojsonSource(glSource, mapView, baseUrl, wrapX) {
-  const use_bbox = (typeof glSource.data === 'string' && glSource.data.indexOf(BBOX_STRING) >= 0);
-  const vector_src = new VectorSource({
-    strategy: use_bbox ? LoadingStrategy.bbox : LoadingStrategy.all,
-    loader: getLoaderFunction(glSource, mapView.getProjection(), baseUrl),
-    useSpatialIndex: true,
-    wrapX: wrapX,
-  });
-
-  // GeoJson sources can be clustered but OpenLayers
-  // uses a special source type for that. This handles the
-  // "switch" of source-class.
-  let new_src = vector_src;
-  if (glSource.cluster) {
-    new_src = new ClusterSource({
-      source: vector_src,
-      // default the distance to 50 as that's what
-      //  is specified by Mapbox.
-      distance: glSource.clusterRadius ? glSource.clusterRadius : 50,
+  return new Promise((resolve) => {
+    const use_bbox = (typeof glSource.data === 'string' && glSource.data.indexOf(BBOX_STRING) >= 0);
+    const vector_src = new VectorSource({
+      strategy: use_bbox ? LoadingStrategy.bbox : LoadingStrategy.all,
+      loader: getLoaderFunction(glSource, mapView.getProjection(), baseUrl),
+      useSpatialIndex: true,
+      wrapX: wrapX,
     });
-  }
 
-  // seed the vector source with the first update
-  //  before returning it.
-  updateGeojsonSource(new_src, glSource, mapView, baseUrl);
-  return new_src;
+    // GeoJson sources can be clustered but OpenLayers
+    // uses a special source type for that. This handles the
+    // "switch" of source-class.
+    let new_src = vector_src;
+    if (glSource.cluster) {
+      new_src = new ClusterSource({
+        source: vector_src,
+        // default the distance to 50 as that's what
+        //  is specified by Mapbox.
+        distance: glSource.clusterRadius ? glSource.clusterRadius : 50,
+      });
+    }
+
+    // seed the vector source with the first update
+    //  before returning it.
+    updateGeojsonSource(new_src, glSource, mapView, baseUrl);
+    resolve(new_src);
+  });
 }
 
 /** Configures a Mapbox GL source object into appropriate
@@ -411,7 +429,9 @@ function configureSource(glSource, mapView, accessToken, baseUrl, time, wrapX) {
   } else if (glSource.type === 'vector') {
     return configureMvtSource(glSource, accessToken);
   }
-  return null;
+  return new Promise((resolve, reject) => {
+    resolve(undefined);
+  });
 }
 
 /** Create a unique key for a group of layers
@@ -588,14 +608,12 @@ export class Map extends React.Component {
 
     // check the sources diff
     const next_sources_version = getVersion(nextProps.map, SOURCE_VERSION_KEY);
-    if (this.sourcesVersion !== next_sources_version) {
-      // go through and update the sources.
-      this.configureSources(nextProps.map.sources, next_sources_version);
-    }
     const next_layer_version = getVersion(nextProps.map, LAYER_VERSION_KEY);
-    if (this.layersVersion !== next_layer_version) {
-      // go through and update the layers.
-      this.configureLayers(nextProps.map.sources, nextProps.map.layers, next_layer_version, nextProps.map.sprite, this.props.declutter);
+    if (this.sourcesVersion !== next_sources_version || this.layersVersion !== next_layer_version) {
+      this.configureSources(nextProps.map.sources, next_sources_version)
+        .then(() => {
+          this.configureLayers(nextProps.map.sources, nextProps.map.layers, next_layer_version, nextProps.map.sprite, this.props.declutter);
+        });
     }
 
     // check the vector sources for data changes
@@ -675,9 +693,11 @@ export class Map extends React.Component {
    *  OpenLayers source definitions.
    *  @param {Object} sourcesDef All sources defined in the Mapbox GL stylesheet.
    *  @param {number} sourceVersion Counter for the source metadata updates.
+   *
+   *  @returns {Promise} When all sources are done, the promise is resolved.
    */
   configureSources(sourcesDef, sourceVersion) {
-    this.sourcesVersion = sourceVersion;
+    const promises = [];
     // TODO: Update this to check "diff" configurations
     //       of sources.  Currently, this will only detect
     //       additions and removals.
@@ -689,21 +709,32 @@ export class Map extends React.Component {
       //  list of sources.
       if (!(src_name in this.sources)) {
         const time = getKey(this.props.map.metadata, TIME_KEY);
-        this.sources[src_name] = configureSource(sourcesDef[src_name], map_view,
-          this.props.mapbox.accessToken, this.props.mapbox.baseUrl, time, this.props.wrapX);
+        promises.push(configureSource(sourcesDef[src_name], map_view,
+          this.props.mapbox.accessToken, this.props.mapbox.baseUrl, time, this.props.wrapX)
+          .then((source) => {
+            if (source) {
+              this.sources[src_name] = source;
+            }
+          })
+        );
       }
       const src = this.props.map.sources[src_name];
       if (src && src.type !== 'geojson' && !jsonEquals(src, sourcesDef[src_name])) {
         // reconfigure source and tell layers about it
-        this.sources[src_name] = configureSource(
+        promises.push(configureSource(
           sourcesDef[src_name],
           map_view,
           this.props.mapbox.accessToken,
           this.props.mapbox.baseUrl,
           undefined,
           this.props.wrapX
-        );
-        this.updateLayerSource(src_name);
+        )
+          .then((source) => {
+            if (source) {
+              this.sources[src_name] = source;
+              this.updateLayerSource(src_name);
+            }
+          }));
       }
 
       // Check to see if there was a clustering change.
@@ -713,16 +744,20 @@ export class Map extends React.Component {
       if (src && (src.cluster !== sourcesDef[src_name].cluster
           || src.clusterRadius !== sourcesDef[src_name].clusterRadius)) {
         // reconfigure the source for clustering.
-        this.sources[src_name] = configureSource(
+        promises.push(configureSource(
           sourcesDef[src_name],
           map_view,
           this.props.mapbox.accessToken,
           this.props.mapbox.baseUrl,
           undefined,
           this.props.wrapX
-        );
-        // tell all the layers about it.
-        this.updateLayerSource(src_name);
+        ).then((source) => {
+          if (source) {
+            this.sources[src_name] = source;
+            // tell all the layers about it.
+            this.updateLayerSource(src_name);
+          }
+        }));
       }
     }
 
@@ -735,6 +770,9 @@ export class Map extends React.Component {
         delete this.sources[src_name];
       }
     }
+    return Promise.all(promises).then(() => {
+      this.sourcesVersion = sourceVersion;
+    });
   }
 
   /** Applies the sprite animation information to the layer
@@ -861,7 +899,9 @@ export class Map extends React.Component {
         if (time && layers[0].metadata && layers[0].metadata[TIME_START_KEY] !== undefined) {
           layers[0].filter = this.props.createLayerFilter(layers[0], time);
         }
+        const tileGrid = source.getTileGrid();
         layer = new VectorTileLayer({
+          maxResolution: tileGrid.getMinZoom() > 0 ? tileGrid.getResolution(tileGrid.getMinZoom()) : undefined,
           declutter: declutter,
           zIndex: idx,
           source,
@@ -1329,9 +1369,13 @@ export class Map extends React.Component {
 
 
     // bootstrap the map with the current configuration.
-    this.configureSources(this.props.map.sources, this.props.map.metadata[SOURCE_VERSION_KEY]);
-    this.configureLayers(this.props.map.sources, this.props.map.layers,
-      this.props.map.metadata[LAYER_VERSION_KEY], this.props.map.sprite, this.props.declutter);
+    if (this.props.map.layers.length > 0) {
+      this.configureSources(this.props.map.sources, this.props.map.metadata[SOURCE_VERSION_KEY])
+        .then(() => {
+          this.configureLayers(this.props.map.sources, this.props.map.layers,
+            this.props.map.metadata[LAYER_VERSION_KEY], this.props.map.sprite, this.props.declutter);
+        });
+    }
 
     // this is done after the map composes itself for the first time.
     //  otherwise the map was not always ready for the initial popups.

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -609,13 +609,14 @@ export class Map extends React.Component {
     // check the sources diff
     const next_sources_version = getVersion(nextProps.map, SOURCE_VERSION_KEY);
     const next_layer_version = getVersion(nextProps.map, LAYER_VERSION_KEY);
-    if (this.sourcesVersion !== next_sources_version || this.layersVersion !== next_layer_version) {
+    if (this.sourcesVersion !== next_sources_version) {
       this.configureSources(nextProps.map.sources, next_sources_version)
         .then(() => {
           this.configureLayers(nextProps.map.sources, nextProps.map.layers, next_layer_version, nextProps.map.sprite, this.props.declutter);
         });
+    } else if (this.layersVersion !== next_layer_version) {
+      this.configureLayers(nextProps.map.sources, nextProps.map.layers, next_layer_version, nextProps.map.sprite, this.props.declutter);
     }
-
     // check the vector sources for data changes
     const src_names = Object.keys(nextProps.map.sources);
     for (let i = 0, ii = src_names.length; i < ii; i++) {


### PR DESCRIPTION
SDK-862

This came up when porting https://github.com/boundlessgeo/ol-mapbox-style/pull/39 to SDK.

So ```type: 'vector'``` comes in two forms:

1. url, this is the url to a TileJSON resource, which is then fetched and parsed, and only then can we construct the actual source
2. tiles, a set of tiles, this is the way we were using url before

So we were incorrectly using url before, where we should have been using tiles. And when using url, it will need async / promise based creation of sources. This had quite a bit of influence on the unit tests, where some of them now need to run in a setTimeout callback.