### PR TITLE
Add currentModeOptions to allow passing options to the mode

### DIFF
--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -485,6 +485,45 @@ describe('MapboxGL component', () => {
     expect(map.draw.changeMode).toHaveBeenCalled();
   });
 
+  it('changes the mode with options', () => {
+    const sources = {
+      geojson: {
+        type: 'geojson',
+      },
+    };
+    const layers = [];
+    const metadata = {
+      'bnd:source-version': 0,
+      'bnd:layer-version': 0,
+      'bnd:data-version:geojson': 0,
+    };
+
+    const center = [0, 0];
+    const zoom = 2;
+    const apiKey = 'foo';
+    const drawing = {
+      interaction: 'Point'
+    };
+    const props = {
+      drawing,
+      mapbox: {accessToken: apiKey},
+      map: {center, zoom, sources, layers, metadata}
+    };
+    const modeOptions = {
+      custom: true
+    };
+    const wrapper = mount(<MapboxGL {...props} />);
+    const map = wrapper.instance();
+    // mock up our GL map
+    map.map = createMapMock();
+    map.draw = createMapDrawMock();
+    const on = () => {};
+    map.map.on = on;
+    spyOn(map.draw, 'changeMode');
+    map.updateInteraction({interaction: 'Polygon', currentMode: 'customMode', currentModeOptions: modeOptions});
+    expect(map.draw.changeMode).toHaveBeenCalledWith('customMode', modeOptions);
+  });
+
   it('updateInteraction with measure works correctly', () => {
     const sources = {
       geojson: {

--- a/src/actions/drawing.js
+++ b/src/actions/drawing.js
@@ -23,16 +23,18 @@ import {INTERACTIONS} from '../constants';
  *  @param {string} drawingType The type of drawing interaction.
  *  @param {string} afterMode The mode to be used after the drawing interaction finishes.
  *  @param {string} currentMode The mode to be used for drawing interaction.
+ *  @param {Object} currentModeOptions The mode options for the currentMode
  *
  *  @returns {Object} An action object to pass to the reducer.
  */
-export function startDrawing(sourceName, drawingType, afterMode, currentMode) {
+export function startDrawing(sourceName, drawingType, afterMode, currentMode, currentModeOptions) {
   return {
     type: DRAWING.START,
     interaction: drawingType,
     sourceName,
     currentMode,
     afterMode,
+    currentModeOptions,
   };
 }
 

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -328,6 +328,10 @@ export class MapboxGL extends React.Component {
     return {};
   }
 
+  modeOptions(modeOptions) {
+    return modeOptions ? modeOptions : {};
+  }
+
   updateInteraction(drawingProps) {
     // this assumes the interaction is different,
     //  so the first thing to do is clear out the old interaction
@@ -340,10 +344,10 @@ export class MapboxGL extends React.Component {
     if (INTERACTIONS.drawing.includes(drawingProps.interaction)) {
       this.currentMode = this.setMode(this.getMode(drawingProps.interaction), drawingProps.currentMode);
       this.afterMode = this.setMode(this.currentMode, drawingProps.afterMode);
-      this.draw.changeMode(this.currentMode);
+      this.draw.changeMode(this.currentMode, this.modeOptions(drawingProps.currentModeOptions));
     } else if (INTERACTIONS.modify === drawingProps.interaction || INTERACTIONS.select === drawingProps.interaction) {
       this.currentMode = this.setMode(SIMPLE_SELECT_MODE, drawingProps.currentMode);
-      this.draw.changeMode(this.currentMode);
+      this.draw.changeMode(this.currentMode, this.modeOptions(drawingProps.currentModeOptions));
       this.afterMode = this.setMode(DIRECT_SELECT_MODE, drawingProps.afterMode);
     } else if (INTERACTIONS.measuring.includes(drawingProps.interaction)) {
       // clear the previous measure feature.
@@ -352,7 +356,7 @@ export class MapboxGL extends React.Component {
       // but are prefixed with "measure:"
       const measureType = drawingProps.interaction.split(':')[1];
       this.currentMode = this.setMode(this.getMode(measureType), drawingProps.currentMode);
-      this.draw.changeMode(this.currentMode);
+      this.draw.changeMode(this.currentMode, this.modeOptions(drawingProps.currentModeOptions));
       if (!this.addedMeasurementListener) {
         this.map.on('draw.render', (evt) => {
           this.onDrawRender(evt);


### PR DESCRIPTION
## What does this PR do?

It adds the ability to pass options to changing the mode to mapbox draw.
More info about custom modes:
https://github.com/mapbox/mapbox-gl-draw/blob/master/docs/MODES.md

### Why? 
we have a use-case where we have a custom mode, which needs more options
passed to it. mapbox draw allows to create custom modes and add options
on initialization (changeMode) to it.
it does not affect any other drawing features