### PR TITLE
Quick fix to check for the existance of sources before trying to call setData

### DIFF
--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -141,12 +141,15 @@ export class MapboxGL extends React.Component {
         const version_key = dataVersionKey(src_name);
         if (this.props.map.metadata !== undefined &&
             this.props.map.metadata[version_key] !== nextProps.map.metadata[version_key] && this.map) {
-          this.map.getSource(src_name).setData(nextProps.map.sources[src_name].data);
-          if (this.draw) {
-            if (nextProps.map.sources[src_name].type === 'geojson') {
-              nextProps.map.sources[src_name].data.features.forEach((feature) => {
-                this.draw.add(feature);
-              });
+          const source = this.map.getSource(src_name);
+          if (source && typeof source !== 'undefined') {
+            source.setData(nextProps.map.sources[src_name].data);
+            if (this.draw) {
+              if (nextProps.map.sources[src_name].type === 'geojson') {
+                nextProps.map.sources[src_name].data.features.forEach((feature) => {
+                  this.draw.add(feature);
+                });
+              }
             }
           }
         }


### PR DESCRIPTION
Under certain circumstances `shouldComponentUpdate` can apparently get called before any sources have been added to the map. This then results in a TypeError:
```
TypeError: Cannot read property 'setData' of undefined
MapboxGL.shouldComponentUpdate
./node_modules/@boundlessgeo/sdk/components/mapboxgl.js:197
  194 | if (src && src.type === 'geojson') {
  195 |   var version_key = (0, _map2.dataVersionKey)(src_name);
  196 |   if (this.props.map.metadata !== undefined && this.props.map.metadata[version_key] !== nextProps.map.metadata[version_key] && this.map) {
> 197 |     this.map.getSource(src_name).setData(nextProps.map.sources[src_name].data);
  198 |     if (this.draw) {
  199 |       if (nextProps.map.sources[src_name].type === 'geojson') {
  200 |         nextProps.map.sources[src_name].data.features.forEach(function (feature) {
```

First of all: React's `shouldComponentUpdate` method is [not really a place intended to cause side-effects](https://medium.com/@baphemot/understanding-reactjs-component-life-cycle-823a640b3e8d#98ae) (like adding features, setting zoom or bearing) as it's done here. I'd recommend to move those calls to `componentDidUpdate` instead. `shouldComponentUpdate` should always only check if a component needs re-rendering and return `true` or `false` 🙂 

To avoid the above error I quickly added a check if `this.map.getSource(src_name)` is not null or undefined before calling the `.setData()` method on it.