### PR TITLE
moving side effects to componentWillReceiveProps

### DIFF
--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -136,7 +136,7 @@ describe('MapboxGL component', () => {
     const removeControl = () => {};
     map.map.removeControl = removeControl;
     spyOn(map.map, 'removeControl');
-    map.shouldComponentUpdate(nextProps);
+    map.componentWillReceiveProps(nextProps);
     expect(types).toEqual(['draw.create', 'draw.update']);
     expect(map.map.setStyle).toHaveBeenCalled();
     expect(map.map.setCenter).toHaveBeenCalled();
@@ -148,11 +148,11 @@ describe('MapboxGL component', () => {
       interaction: 'Polygon',
       sourceName: 'geojson',
     };
-    map.shouldComponentUpdate(nextProps);
+    map.componentWillReceiveProps(nextProps);
     expect(map.updateInteraction).toHaveBeenCalled();
     delete nextProps.map.metadata;
     nextProps.map.sources = {};
-    map.shouldComponentUpdate(nextProps);
+    map.componentWillReceiveProps(nextProps);
     expect(map.sourcesVersion).not.toBeDefined();
     expect(map.layersVersion).not.toBeDefined();
   });

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -107,6 +107,12 @@ export class MapboxGL extends React.Component {
    * @returns {boolean} should the component re-render?
    */
   shouldComponentUpdate(nextProps) {
+    // This should always return false to keep
+    // render() from being called.
+    return false;
+  }
+
+  componentWillReceiveProps(nextProps) {
     // check if the sources or layers diff
     const next_sources_version = getVersion(nextProps.map, SOURCE_VERSION_KEY);
     const next_layer_version = getVersion(nextProps.map, LAYER_VERSION_KEY);
@@ -160,9 +166,6 @@ export class MapboxGL extends React.Component {
         || nextProps.drawing.sourceName !== this.props.drawing.sourceName)) {
       this.updateInteraction(nextProps.drawing);
     }
-    // This should always return false to keep
-    // render() from being called.
-    return false;
   }
 
   onMapClick(e) {


### PR DESCRIPTION
Moved side effects from `shouldComponentUpdate` to `componentWillReceiveProps` since side effects in `shouldComponentUpdate` should be avoided.