### PR TITLE
Fix several issues with the drawing tools

### DIFF
--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -107,6 +107,8 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance();
     // mock up our GL map
     map.map = createMapMock();
+    map.map.on = () => {};
+    map.map.off = () => {};
     map.draw = createMapDrawMock();
     spyOn(map.map, 'setStyle');
     spyOn(map.map, 'setCenter');
@@ -264,10 +266,13 @@ describe('MapboxGL component', () => {
     spyOn(props, 'onFeatureDrawn');
     const wrapper = mount(<MapboxGL {...props} />);
     const map = wrapper.instance();
-    const feature = {
-      type: 'Feature',
+    const collection = {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+      }],
     };
-    map.onFeatureEvent('drawn', 'foo', feature);
+    map.onFeatureEvent('drawn', 'foo', collection);
     expect(props.onFeatureDrawn).toHaveBeenCalled();
   });
 
@@ -279,26 +284,14 @@ describe('MapboxGL component', () => {
     spyOn(props, 'onFeatureModified');
     const wrapper = mount(<MapboxGL {...props} />);
     const map = wrapper.instance();
-    const feature = {
-      type: 'Feature',
+    const collection = {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+      }],
     };
-    map.onFeatureEvent('modified', 'foo', feature);
+    map.onFeatureEvent('modified', 'foo', collection);
     expect(props.onFeatureModified).toHaveBeenCalled();
-  });
-
-  it('selected event should be triggered', () => {
-    const onFeatureSelected = () => {};
-    const props = {
-      onFeatureSelected,
-    };
-    spyOn(props, 'onFeatureSelected');
-    const wrapper = mount(<MapboxGL {...props} />);
-    const map = wrapper.instance();
-    const feature = {
-      type: 'Feature',
-    };
-    map.onFeatureEvent('selected', 'foo', feature);
-    expect(props.onFeatureSelected).toHaveBeenCalled();
   });
 
   it('configureMap sets listeners', () => {
@@ -740,14 +733,18 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance();
     // mock up our GL map
     map.map = createMapMock();
+    map.map.on = () => {};
+    map.map.off = () => {};
     spyOn(props, 'onFeatureDrawn');
     const draw = {
       changeMode: (mode) => {}
     };
     spyOn(draw, 'changeMode');
+    map.draw = draw;
+    map.componentWillReceiveProps({map: {sources: {}, metadata: {}, layers: []}, drawing: {sourceName: 'geosjon'}});
     map.onDrawCreate({
       features: [{}]
-    }, {sourceName: 'geosjon'}, draw, 'draw_polygon');
+    }, 'draw_polygon');
     window.setTimeout(function() {
       expect(draw.changeMode).toHaveBeenCalled();
       done();
@@ -823,6 +820,8 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance();
     // mock up our GL map
     map.map = createMapMock();
+    map.map.on = () => {};
+    map.map.off = () => {};
     map.draw = createMapDrawMock();
     map.addedDrawListener = true;
     const drawingProps = {

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,9 @@
 
 ### Next Release
 
+#### onFeatureDrawn, onFeatureModified
+To sync with the behaviour of the Map component, the MapboxGL component has also been adapted so that the onFeatureDrawn and onFeatureModified callbacks now get a collection of features instead of a single feature.
+
 ### v2.3.0
 
 #### onFeatureDrawn, onFeatureModified, onFeatureSelected

--- a/examples/drawing/app.js
+++ b/examples/drawing/app.js
@@ -96,6 +96,20 @@ function main() {
   }));
   store.dispatch(drawingActions.setEditStyle([
     {
+      'id': 'gl-draw-line',
+      'type': 'line',
+      'filter': ['all', ['==', '$type', 'LineString'], ['!=', 'mode', 'static']],
+      'layout': {
+        'line-cap': 'round',
+        'line-join': 'round'
+      },
+      'paint': {
+        'line-color': '#D20C0C',
+        'line-dasharray': [0.2, 2],
+        'line-width': 2
+      }
+    },
+    {
       'id': 'gl-draw-polygon-fill-inactive',
       'type': 'fill',
       'filter': ['all',
@@ -229,7 +243,9 @@ function main() {
     if (drawing_tool === 'none') {
       store.dispatch(drawingActions.endDrawing());
     } else if (drawing_layer !== null) {
-      store.dispatch(drawingActions.startDrawing(drawing_layer, drawing_tool, 'direct_select'));
+      // direct_select mode doesn't handle point features
+      const mode = drawing_layer !== 'points' ? 'direct_select' : undefined;
+      store.dispatch(drawingActions.startDrawing(drawing_layer, drawing_tool, mode));
     }
   };
 


### PR DESCRIPTION
SDK-880

1. no box zoom anymore in mapbox gl map
2. onFeatureXXX callbacks need to pass a collection now
3. sourceName in callback functions should be correct
4. lines are not visible when drawing with the openlayers map in the draw example

So the draw control disabled the box zoom, see: https://github.com/mapbox/mapbox-gl-draw/blob/master/src/setup.js#L36

So we should only create the draw control when we actually need it.

In addition in #804 we had changed the interface of the onFeatureXXX callback functions to pass a collection instead of a single feature, but this had not yet been changed in the mapbox gl map component, so the drawing example was broken for the mapbox renderer, this PR also addresses this