### PR TITLE
Check for existence of sources before using them

### DIFF
--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -406,6 +406,9 @@ function removeSource(state, action) {
  */
 function changeData(state, sourceName, data) {
   const source = state.sources[sourceName];
+  if (!source) {
+    return;
+  }
   const src_mixin = {};
 
   // update the individual source.
@@ -427,6 +430,9 @@ function changeData(state, sourceName, data) {
  */
 function addFeatures(state, action) {
   const source = state.sources[action.sourceName];
+  if (!source) {
+    return;
+  }
   const data = source.data;
 
   // placeholder for the new data
@@ -485,6 +491,9 @@ function addFeatures(state, action) {
  */
 function clusterPoints(state, action) {
   const source = state.sources[action.sourceName];
+  if (!source) {
+    return;
+  }
   const src_mixin = [];
   const cluster_settings = {};
 
@@ -518,6 +527,9 @@ function clusterPoints(state, action) {
 function removeFeatures(state, action) {
   // short hand the source source and the data
   const source = state.sources[action.sourceName];
+  if (!source) {
+    return;
+  }
   const data = source.data;
 
   // filter function, features which MATCH this function will be REMOVED.

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -407,7 +407,7 @@ function removeSource(state, action) {
 function changeData(state, sourceName, data) {
   const source = state.sources[sourceName];
   if (!source) {
-    return;
+    return state;
   }
   const src_mixin = {};
 
@@ -431,7 +431,7 @@ function changeData(state, sourceName, data) {
 function addFeatures(state, action) {
   const source = state.sources[action.sourceName];
   if (!source) {
-    return;
+    return state;
   }
   const data = source.data;
 
@@ -492,7 +492,7 @@ function addFeatures(state, action) {
 function clusterPoints(state, action) {
   const source = state.sources[action.sourceName];
   if (!source) {
-    return;
+    return state;
   }
   const src_mixin = [];
   const cluster_settings = {};
@@ -528,7 +528,7 @@ function removeFeatures(state, action) {
   // short hand the source source and the data
   const source = state.sources[action.sourceName];
   if (!source) {
-    return;
+    return state;
   }
   const data = source.data;
 


### PR DESCRIPTION
Same problem as described here earlier this week: https://github.com/boundlessgeo/sdk/pull/817

Under certain (asynchronous) conditions it might happen that you try to add, change or remove a feature on a source which has not been added yet or has already been removed. With this PR functions which are accessing a specific source simply return the old state if the source does not yet or no longer exists.