### PR TITLE
More thorough test for size changes.

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -644,7 +644,9 @@ export class Map extends React.Component {
       this.map.renderSync();
     }
 
-    if (nextProps.mapinfo && this.props.mapinfo.size !== null && (nextProps.mapinfo.size[0] !== this.props.mapinfo.size[0] || nextProps.mapinfo.size[1] !== this.props.mapinfo.size[1])) {
+    const size = this.props.mapinfo !== undefined ? this.props.mapinfo.size : null;
+    const next_size = nextProps.mapinfo !== undefined ? nextProps.mapinfo.size : null;
+    if (size && next_size && (size[0] !== next_size[0] || size[1] !== next_size[1])) {
       this.map.updateSize();
     }
 


### PR DESCRIPTION
Tests for null and undefined in the current and next states.

I found some situations where unloading and loading the map could cause odd states in the mapinfo reducer's size.