### PR TITLE
Remove artifacts from map

### DIFF
--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -17,6 +17,8 @@ const createMapDrawMock = () => {
   return {
     changeMode: () => {},
     getAll: () => {},
+    add: () => {},
+    deleteAll: () => {}
   };
 };
 const createMapMock = () => {
@@ -32,6 +34,8 @@ const createMapMock = () => {
     setBearing: () => {},
     setZoom: () => {},
     addControl: () => {},
+    on: () => {},
+    off: () => {},
     queryRenderedFeatures: () => {
       return [{
         layer: {
@@ -476,6 +480,48 @@ describe('MapboxGL component', () => {
     spyOn(map.draw, 'changeMode');
     map.updateInteraction({interaction: 'Polygon'});
     expect(map.draw.changeMode).toHaveBeenCalled();
+  });
+
+  it('updateInteraction adds the features to draw', () => {
+    const sources = {
+      geojson: {
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection',
+          features: [{id: '1'}]
+        }
+      },
+    };
+    const layers = [];
+    const metadata = {
+      'bnd:source-version': 0,
+      'bnd:layer-version': 0,
+      'bnd:data-version:geojson': 0,
+    };
+
+    const center = [0, 0];
+    const zoom = 2;
+    const apiKey = 'foo';
+    const drawing = {
+      interaction: 'Point'
+    };
+    const props = {
+      drawing,
+      mapbox: {accessToken: apiKey},
+      map: {center, zoom, sources, layers, metadata}
+    };
+    const wrapper = mount(<MapboxGL {...props} />);
+    const map = wrapper.instance();
+    // mock up our GL map
+    map.map = createMapMock();
+    map.draw = createMapDrawMock();
+    const on = () => {};
+    map.map.on = on;
+    spyOn(map.draw, 'deleteAll');
+    spyOn(map.draw, 'add');
+    map.updateInteraction({interaction: 'Polygon', sourceName: 'geojson'});
+    expect(map.draw.deleteAll).toHaveBeenCalled();
+    expect(map.draw.add).toHaveBeenCalled();
   });
 
   it('changes the mode with options', () => {

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -154,18 +154,6 @@ export class MapboxGL extends React.Component {
           const source = this.map.getSource(src_name);
           if (source && typeof source !== 'undefined') {
             source.setData(nextProps.map.sources[src_name].data);
-            if (this.draw) {
-              if (nextProps.map.sources[src_name].type === 'geojson') {
-                this.props.map.sources[src_name].data.features.forEach((feature) => {
-                  if (feature.id) {
-                    this.draw.delete(feature.id);
-                  }
-                });
-                nextProps.map.sources[src_name].data.features.forEach((feature) => {
-                  this.draw.add(feature);
-                });
-              }
-            }
           }
         }
       }
@@ -349,6 +337,15 @@ export class MapboxGL extends React.Component {
     return modeOptions ? modeOptions : {};
   }
 
+  addFeaturesToDrawForSource(sourceName) {
+    if(this.draw) {
+      this.draw.deleteAll();
+      this.props.map.sources[sourceName].data.features.forEach((feature) => {
+        this.draw.add(feature);
+      });
+    }
+  }
+
   updateInteraction(drawingProps) {
     // this assumes the interaction is different,
     //  so the first thing to do is clear out the old interaction
@@ -359,14 +356,17 @@ export class MapboxGL extends React.Component {
       this.activeInteractions = null;
     }
     if (INTERACTIONS.drawing.includes(drawingProps.interaction)) {
+      this.addFeaturesToDrawForSource(drawingProps.sourceName);
       this.currentMode = this.setMode(this.getMode(drawingProps.interaction), drawingProps.currentMode);
       this.afterMode = this.setMode(this.currentMode, drawingProps.afterMode);
       this.draw.changeMode(this.currentMode, this.modeOptions(drawingProps.currentModeOptions));
     } else if (INTERACTIONS.modify === drawingProps.interaction || INTERACTIONS.select === drawingProps.interaction) {
+      this.addFeaturesToDrawForSource(drawingProps.sourceName);
       this.currentMode = this.setMode(SIMPLE_SELECT_MODE, drawingProps.currentMode);
       this.draw.changeMode(this.currentMode, this.modeOptions(drawingProps.currentModeOptions));
       this.afterMode = this.setMode(DIRECT_SELECT_MODE, drawingProps.afterMode);
     } else if (INTERACTIONS.measuring.includes(drawingProps.interaction)) {
+      this.addFeaturesToDrawForSource(drawingProps.sourceName);
       // clear the previous measure feature.
       this.props.clearMeasureFeature();
       // The measure interactions are the same as the drawing interactions

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -157,7 +157,9 @@ export class MapboxGL extends React.Component {
             if (this.draw) {
               if (nextProps.map.sources[src_name].type === 'geojson') {
                 this.props.map.sources[src_name].data.features.forEach((feature) => {
-                  this.draw.delete(feature.properties.id);
+                  if (feature.id) {
+                    this.draw.delete(feature.id);
+                  }
                 });
                 nextProps.map.sources[src_name].data.features.forEach((feature) => {
                   this.draw.add(feature);

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -156,6 +156,9 @@ export class MapboxGL extends React.Component {
             source.setData(nextProps.map.sources[src_name].data);
             if (this.draw) {
               if (nextProps.map.sources[src_name].type === 'geojson') {
+                this.props.map.sources[src_name].data.features.forEach((feature) => {
+                  this.draw.delete(feature.properties.id);
+                });
                 nextProps.map.sources[src_name].data.features.forEach((feature) => {
                   this.draw.add(feature);
                 });
@@ -376,7 +379,9 @@ export class MapboxGL extends React.Component {
         this.addedMeasurementListener = true;
       }
     } else {
-      this.draw.changeMode(STATIC_MODE);
+      if(this.draw) {
+        this.draw.changeMode(STATIC_MODE);
+      }
     }
     if (drawingProps.sourceName) {
       const drawCreate = (evt) => {

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -379,7 +379,7 @@ export class MapboxGL extends React.Component {
         this.addedMeasurementListener = true;
       }
     } else {
-      if(this.draw) {
+      if (this.draw) {
         this.draw.changeMode(STATIC_MODE);
       }
     }

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -338,11 +338,13 @@ export class MapboxGL extends React.Component {
   }
 
   addFeaturesToDrawForSource(sourceName) {
-    if(this.draw) {
+    if (this.draw) {
       this.draw.deleteAll();
-      this.props.map.sources[sourceName].data.features.forEach((feature) => {
-        this.draw.add(feature);
-      });
+      if (this.props.map.sources[sourceName] && this.props.map.sources[sourceName].data && this.props.map.sources[sourceName].data.features) {
+        this.props.map.sources[sourceName].data.features.forEach((feature) => {
+          this.draw.add(feature);
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

When the source is updated we need to remove the old features from the
draw instance, otherwise there will be artifacts in mapbox draw with a
layername `.cold` or similar. ensure we delete all the features from
draw before adding them again. this avoids adding features multiple
times as well
will add delete feature to the demo shortly after this PR.

fixed a bug as well for the draeing demo.

You got an error when you changed the layer but did not select a different mode resulting in `this.draw` to be undefined. 