### PR TITLE
1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boundless-sdk-build",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "SDK for OpenLayers 3 and React plus Flux",
   "main": "index.js",
   "repository": {

--- a/src/services/MapConfigService.js
+++ b/src/services/MapConfigService.js
@@ -60,7 +60,11 @@ class MapConfigService {
       return source;
     }
     var sourceObj = new ol.source[config.type](props);
-    if (opt_proxy && config.type === 'TileWMS') {
+    var proxyTiles = function(opt_proxy, config) {
+      return opt_proxy && (config.type === 'TileWMS' ||
+        (typeof config['use_proxy'] !== "undefined" && config['use_proxy'] === true));
+    };
+    if (proxyTiles(opt_proxy, config)) {
       sourceObj.once('tileloaderror', function() {
         sourceObj.setTileLoadFunction((function() {
           var tileLoadFn = sourceObj.getTileLoadFunction();

--- a/src/services/MapConfigTransformService.js
+++ b/src/services/MapConfigTransformService.js
@@ -352,6 +352,9 @@ class MapConfigTransformService {
         layerConfig = undefined;
       }
       if (layerConfig !== undefined) {
+        if (typeof source['use_proxy'] !== 'undefined' && source['use_proxy'] !== '') {
+           layerConfig.source['use_proxy'] = source['use_proxy'];
+        }
         if (layer.group) {
           if (layer.group === gxpGroup) {
             layerConfig.properties.type = 'base';


### PR DESCRIPTION
Allow sdk to evaluate a `use_proxy` source parameter if passed into it such that it will get the proxied url for any source, not just TileWMS.

Customized basemaps will also be handled, but are handled on the GeoNode side. The SDK code just assumes the `use_proxy` parameter will be passed in with basemaps as well, and treats them the same.

I didn't have time to quite figure out how to allow proxying for the hadcoded OSM basemap, but I think it might require a flag from GeoNode in addition to `use_proxy`.