### PR TITLE
Fix proxying of ArcGISRestLegend.

### DIFF
--- a/__tests__/services/ArcGISRestService.test.js
+++ b/__tests__/services/ArcGISRestService.test.js
@@ -93,8 +93,8 @@ describe('ArcGISRestService', function() {
   });
 
   it('creates correct legend url', function() {
-    var url = ArcGISRestService.getLegendUrl('http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer');
-    assert.equal(url, 'http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer/legend?f=json&pretty=false&callback=__cbname__');
+    var legendUrl = ArcGISRestService.getLegendUrl(layer.getSource());
+    assert.equal(legendUrl, 'http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer/legend?f=json&pretty=false&callback=__cbname__');
   });
 
   it('creates correct get feature url', function() {

--- a/src/components/ArcGISRestLegend.js
+++ b/src/components/ArcGISRestLegend.js
@@ -54,13 +54,8 @@ class ArcGISRestLegend extends React.PureComponent {
   componentDidMount() {
     var layer = this.props.layer;
     var source = layer.getSource();
-    var url = source.getUrls()[0];
-    // proxy the legend graphic
-    if (typeof source.opt_proxy !== 'undefined' && typeof source.use_proxy !== 'undefined' && source.use_proxy === true) {
-      url = util.getProxiedUrl(url, source.opt_proxy);
-    }
     var me = this;
-    ArcGISRestService.getLegend(url, function(jsonData) {
+    ArcGISRestService.getLegend(source, function(jsonData) {
       if (me._unmounted !== true) {
         me.setState({legendInfo: jsonData});
       }

--- a/src/services/ArcGISRestService.js
+++ b/src/services/ArcGISRestService.js
@@ -70,17 +70,24 @@ class ArcGISRestService {
       onSuccess.call(this, this.parseCapabilities(jsonData));
     }, onFailure, this);
   }
-  getLegendUrl(url) {
+  getLegendUrl(source) {
+    var url = source.getUrls()[0];
     var urlObj = new URL(url + '/legend');
+
     urlObj.set('query', {
       f: 'json',
       pretty: 'false',
       callback: '__cbname__'
     });
-    return urlObj.toString();
+    var legendUrl = urlObj.toString();
+    // proxy the legend graphic url
+    if (typeof source.opt_proxy !== 'undefined' && typeof source.use_proxy !== 'undefined' && source.use_proxy === true) {
+      legendUrl = util.getProxiedUrl(legendUrl, source.opt_proxy);
+    }
+    return legendUrl;
   }
-  getLegend(url, onSuccess) {
-    util.doJSONP(this.getLegendUrl(url), function(jsonData) {
+  getLegend(source, onSuccess) {
+    util.doJSONP(this.getLegendUrl(source), function(jsonData) {
       onSuccess.call(this, jsonData);
     }, undefined, this);
   }


### PR DESCRIPTION
Need to defer getLegendUrl to using source which has knowledge of proxy. Updating test to reflect change

NOTE: Test needs to be updated to use source in the same manner as the function has been changed.

This change has been done to properly proxy the legend graphic, as the previous implementation was unsuccessful. The proxying needs to be done after the url manipulation within the ArcGISRestService.