### PR TITLE
Handle correctly if positionId not found

### DIFF
--- a/__tests__/reducers/map.test.js
+++ b/__tests__/reducers/map.test.js
@@ -113,6 +113,132 @@ describe('map reducer', () => {
     });
   });
 
+  it('should handle ADD_LAYER with unknown positionId', () => {
+    const title = 'Background';
+    const layer = {
+      id: 'background',
+      type: 'background',
+      paint: {
+        'background-color': 'rgba(0,0,0,0)',
+      },
+    };
+    deepFreeze(layer);
+    const action = {
+      type: MAP.ADD_LAYER,
+      layerDef: layer,
+      layerTitle: title,
+      positionId: 'foo',
+    };
+    deepFreeze(action);
+    const initialState = {
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      bearing: 0,
+      metadata: {
+        'bnd:source-version': 0,
+        'bnd:layer-version': 0,
+      },
+      sources: {},
+      layers: [
+        {
+          id: 'osm',
+        },
+      ],
+    };
+    deepFreeze(initialState);
+    expect(reducer(initialState, action)).toEqual({
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      bearing: 0,
+      metadata: {
+        'bnd:source-version': 0,
+        'bnd:layer-version': 1,
+      },
+      sources: {},
+      layers: [
+        {
+          id: 'osm',
+        }, {
+          id: 'background',
+          type: 'background',
+          paint: {
+            'background-color': 'rgba(0,0,0,0)',
+          },
+          metadata: {
+            'bnd:title': title,
+          },
+        },
+      ],
+    });
+  });
+
+  it('should handle ADD_LAYER with known positionId', () => {
+    const title = 'Background';
+    const layer = {
+      id: 'background',
+      type: 'background',
+      paint: {
+        'background-color': 'rgba(0,0,0,0)',
+      },
+    };
+    deepFreeze(layer);
+    const action = {
+      type: MAP.ADD_LAYER,
+      layerDef: layer,
+      layerTitle: title,
+      positionId: 'osm',
+    };
+    deepFreeze(action);
+    const initialState = {
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      bearing: 0,
+      metadata: {
+        'bnd:source-version': 0,
+        'bnd:layer-version': 0,
+      },
+      sources: {},
+      layers: [
+        {
+          id: 'osm',
+        },
+      ],
+    };
+    deepFreeze(initialState);
+    expect(reducer(initialState, action)).toEqual({
+      version: 8,
+      name: 'default',
+      center: [0, 0],
+      zoom: 3,
+      bearing: 0,
+      metadata: {
+        'bnd:source-version': 0,
+        'bnd:layer-version': 1,
+      },
+      sources: {},
+      layers: [
+        {
+          id: 'background',
+          type: 'background',
+          paint: {
+            'background-color': 'rgba(0,0,0,0)',
+          },
+          metadata: {
+            'bnd:title': title,
+          },
+        }, {
+          id: 'osm',
+        },
+      ],
+    });
+  });
+
   it('should handle SET_NAME', () => {
     const state = {
       version: 8,

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -95,7 +95,7 @@ function placeLayer(state, layer, targetId) {
   if (idx1 !== -1) {
     new_layers.splice(idx1, 1);
   }
-  const newIndex = targetId ? idx2 : new_layers.length;
+  const newIndex = (targetId && idx2 !== -1) ? idx2 : new_layers.length;
   new_layers.splice(newIndex, 0, layer);
   return Object.assign({}, state, {
     layers: new_layers,


### PR DESCRIPTION
This came up in SDK-951 where the order of the layer stack in the preview map was incorrect. This is because we were passing positionId to the measure layer in the action, but the measure layer is not in the preview map stack. This PR handles this case more gracefully, as if no positionId was passed at all in case it's not found. Also adds tests which were missing altogether for positionId.