### PR TITLE
Add a prop to make a map not interactive

### DIFF
--- a/__tests__/components/map.test.js
+++ b/__tests__/components/map.test.js
@@ -50,6 +50,11 @@ describe('Map component', () => {
     expect(wrapper.find('.foo').length).toBe(1);
   });
 
+  it('should render a non interactive map', () => {
+    const wrapper = mount(<Map interactive={false} />);
+    expect(wrapper.instance().map.getInteractions().getLength()).toBe(0);
+  });
+
   it('should create a map', (done) => {
 
     // eslint-disable-next-line

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -1476,7 +1476,7 @@ export class Map extends React.Component {
     const minZoom = getKey(this.props.map.metadata, MIN_ZOOM_KEY);
     const maxZoom = getKey(this.props.map.metadata, MAX_ZOOM_KEY);
     this.map = new OlMap({
-      interactions: interaction.defaults(),
+      interactions: this.props.interactive ? interaction.defaults() : [],
       controls: [new AttributionControl()],
       target: this.mapdiv,
       logo: false,
@@ -1738,10 +1738,15 @@ Map.propTypes = {
    * Should we stop events in the popup overlay?
    */
   stopEvent: PropTypes.bool,
+  /**
+   * Should we be interactive? I.e. respond to mouse and keyboard events?
+   */
+  interactive: PropTypes.bool,
 };
 
 Map.defaultProps = {
   ...MapCommon.defaultProps,
+  interactive: true,
   stopEvent: false,
   fetchOptions: {
     credentials: 'same-origin',


### PR DESCRIPTION
If set to false, the map will not have any interactions in it, and hence will not response to any mouse or keyboard events