### PR TITLE
Use show in layers parameter value for ArcGIS REST

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "boundless-sdk-build",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "SDK for OpenLayers 3 and React plus Flux",
   "main": "index.js",
   "repository": {

--- a/src/services/MapConfigTransformService.js
+++ b/src/services/MapConfigTransformService.js
@@ -250,7 +250,7 @@ class MapConfigTransformService {
             crossOrigin: crossOrigin,
             urls: [url],
             params: {
-              LAYERS: layer.layerid,
+              LAYERS: 'show:' + layer.layerid,
               FORMAT: layer.format
             }
           }


### PR DESCRIPTION
Uses the layer.layerid to `show` only this ArcREST layer

https://developers.arcgis.com/rest/services-reference/export-map.htm - see `layers`, `show` param