### PR TITLE
Handle promise rejection from ol-mapbox-style applyStyle

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -993,7 +993,9 @@ export class Map extends React.Component {
       this.props.mapbox.accessToken,
     );
     if (olLayer.setStyle && spriteLayers.length === 0) {
-      applyStyle(olLayer, fake_style, layers[0].source);
+      applyStyle(olLayer, fake_style, layers[0].source).catch((error) => {
+        console.error('An error occured.', error);
+      });
     }
 
     if (layers.length === 1 && layers[0].type === 'raster') {


### PR DESCRIPTION
ol-mapbox-style applyStyle returns a promise that can get rejected if the sprite cannot be loaded, and we were not handling this