### PR TITLE
Fix undefined refs which kills Mapbox libs, have default zoom and center

### DIFF
--- a/__tests__/components/map.test.js
+++ b/__tests__/components/map.test.js
@@ -536,8 +536,8 @@ describe('Map component', () => {
     const view = map.getView();
     // default values should get set
     expect(view.getRotation()).toBe(0);
-    expect(view.getCenter()).toBe(null);
-    expect(view.getZoom()).toBe(undefined);
+    expect(view.getCenter()).toEqual([0, 0]);
+    expect(view.getZoom()).toBe(1);
   });
 
   it('should handle undefined center, zoom, bearing in componentWillReceiveProps', () => {

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -524,7 +524,7 @@ export function hydrateLayer(layersDef, glLayer) {
     // clone the gl layer
     layer_def = jsonClone(glLayer);
     // remove the reference
-    layer_def.ref = undefined;
+    delete layer_def.ref;
     // mixin the layer_def to the ref layer.
     layer_def = Object.assign({}, ref_layer, layer_def);
   }
@@ -1502,8 +1502,15 @@ export class Map extends React.Component {
     let center;
     if (this.props.map.center !== undefined) {
       center = Proj.transform(this.props.map.center, 'EPSG:4326', map_proj);
+    } else {
+      center = [0, 0];
     }
-
+    let zoom;
+    if (this.props.map.zoom !== undefined) {
+      zoom = this.props.map.zoom + 1;
+    } else {
+      zoom = 1;
+    }
     // initialize the map.
     const minZoom = getKey(this.props.map.metadata, MIN_ZOOM_KEY);
     const maxZoom = getKey(this.props.map.metadata, MAX_ZOOM_KEY);
@@ -1516,7 +1523,7 @@ export class Map extends React.Component {
         minZoom: minZoom ? minZoom + 1 : undefined,
         maxZoom: maxZoom ? maxZoom + 1 : undefined,
         center,
-        zoom: this.props.map.zoom >= 0 ? this.props.map.zoom + 1 : this.props.map.zoom,
+        zoom,
         rotation: rotation !== undefined ? -rotation : 0,
         projection: map_proj,
       }),


### PR DESCRIPTION
This is taken from #861 since it might take a while before we upgrade, and it fixes actual issues in the current code base