### PR TITLE
Do not redefine setSourceError from import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     },
     "extends": ["react-app", "openlayers"],
     "rules": {
+        "no-shadow": "error",
         "comma-dangle": 0,
         "import/no-extraneous-dependencies": 0,
         "no-console": ["error", {

--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -732,7 +732,7 @@ describe('MapboxGL component', () => {
     map.map = createMapMock();
     const popupId = 'foo';
     // mock overlay and popup
-    const setMap = (map) => {};
+    const setMap = () => {};
     const popup = {
       setMap,
       state: {

--- a/__tests__/components/wfs.test.js
+++ b/__tests__/components/wfs.test.js
@@ -58,7 +58,7 @@ describe('WfsController component.', () => {
 
   it('handles exception reports', (done) => {
     // eslint-disable-next-lint
-    const error = '<ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/ows https://demo.boundlessgeo.com/geoserver/schemas/ows/1.0.0/owsExceptionReport.xsd"><ows:Exception exceptionCode="NoApplicableCode"><ows:ExceptionText>Transaction support is not enabled</ows:ExceptionText></ows:Exception></ows:ExceptionReport>';
+    const exception = '<ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/ows https://demo.boundlessgeo.com/geoserver/schemas/ows/1.0.0/owsExceptionReport.xsd"><ows:Exception exceptionCode="NoApplicableCode"><ows:ExceptionText>Transaction support is not enabled</ows:ExceptionText></ows:Exception></ows:ExceptionReport>';
 
     let message;
 
@@ -81,7 +81,7 @@ describe('WfsController component.', () => {
 
     nock('http://exception.com')
       .post('/wfs')
-      .reply(200, error, {
+      .reply(200, exception, {
         'Content-Type': 'application/xml',
       });
     store.dispatch(actions.updateFeature('exception-source', feature));

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -1376,7 +1376,7 @@ export class Map extends React.Component {
               srsName: 'EPSG:4326',
               'cql_filter': `BBOX(${geomName},${bbox[0]},${bbox[1]},${bbox[2]},${bbox[3]},'${this.props.projection}')`,
             }, layer.metadata[QUERY_PARAMS_KEY]);
-            const url = `${layer.metadata[QUERY_ENDPOINT_KEY]}?${encodeQueryObject(params)}`;
+            url = `${layer.metadata[QUERY_ENDPOINT_KEY]}?${encodeQueryObject(params)}`;
             fetch(url, fetchOptions).then(
               response => response.json(),
               error => console.error('An error occured.', error),

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -838,10 +838,10 @@ export class Map extends React.Component {
     let src_names = Object.keys(sourcesDef);
     const map_view = this.map.getView();
 
-    const setSourceError = this.props.setSourceError;
+    const sourceError = this.props.setSourceError;
     const listenForError = (src_name, source) => {
       source.on('tileloaderror', () => {
-        setSourceError(src_name);
+        sourceError(src_name);
       });
     };
 


### PR DESCRIPTION
This is to fix:
```
Uncaught TypeError: setSourceError is not a function
    at _ol_source_TileWMS_.<anonymous> (map.js:977)
    at _ol_source_TileWMS_.boundListener (events.js:16)
    at _ol_source_TileWMS_../node_modules/ol/events/eventtarget.js._ol_events_EventTarget_.dispatchEvent (eventtarget.js:86)
    at _ol_source_TileWMS_../node_modules/ol/source/urltile.js._ol_source_UrlTile_.handleTileChange (urltile.js:132)
    at _ol_ImageTile_.boundListener (events.js:16)
    at _ol_ImageTile_../node_modules/ol/events/eventtarget.js._ol_events_EventTarget_.dispatchEvent (eventtarget.js:86)
    at _ol_ImageTile_../node_modules/ol/tile.js._ol_Tile_.changed (tile.js:73)
    at _ol_ImageTile_../node_modules/ol/imagetile.js._ol_ImageTile_.handleImageError_ (imagetile.js:106)
    at Image.boundListener (events.js:16)
```