### PR TITLE
Add default prop for setSourceError

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -1867,6 +1867,8 @@ Map.defaultProps = {
   },
   clearSourceErrors: () => {
   },
+  setSourceError: () => {
+  },
 };
 
 function mapStateToProps(state) {


### PR DESCRIPTION
So it doesn't fail when used from the not connected component class