### PR TITLE
We should not feed geometry in EPSG:4326 to getArea

### DIFF
--- a/src/components/map.js
+++ b/src/components/map.js
@@ -1923,9 +1923,7 @@ function mapDispatchToProps(dispatch) {
           segments.push(getDistance(a, b));
         }
       } else if (geom.type === 'Polygon' && geom.coordinates.length > 0) {
-        const clone = geometry.clone();
-        clone.transform(projection, 'EPSG:4326');
-        segments.push(getArea(clone));
+        segments.push(getArea(geometry, {projection}));
       }
 
 


### PR DESCRIPTION
This came up in MBSE-168

See the OpenLayers API docs for getArea:
```
 * Get the spherical area of a geometry.  This is the area (in meters) assuming
 * that polygon edges are segments of great circles on a sphere.
 * @param {module:ol/geom/Geometry} geometry A geometry.
 * @param {module:ol/sphere~SphereMetricOptions=} opt_options Options for the area
 *     calculation.  By default, geometries are assumed to be in 'EPSG:3857'.
 *     You can change this by providing a `projection` option.
 * @return {number} The spherical area (in square meters).
 */
```

We were doing the transform ourselves, and not passing in the projection.