### PR TITLE
Allow setting fetch options at the source level

### DIFF
--- a/__tests__/components/map-geojson-source.test.js
+++ b/__tests__/components/map-geojson-source.test.js
@@ -16,6 +16,7 @@ import MapboxReducer from '@boundlessgeo/sdk/reducers/mapbox';
 import MapInfoReducer from '@boundlessgeo/sdk/reducers/mapinfo';
 import * as MapActions from '@boundlessgeo/sdk/actions/map';
 import * as MapboxActions from '@boundlessgeo/sdk/actions/mapbox';
+import {SOURCES_FETCH_OPTIONS_KEY} from '@boundlessgeo/sdk/constants';
 
 configure({adapter: new Adapter()});
 
@@ -130,6 +131,25 @@ describe('tests for the geojson-type map sources', () => {
       .reply(200, JSON.stringify(feature_collection));
 
     testGeojsonData(done, 'http://example.com/test.geojson', 2);
+  });
+
+  it('uses fetch options from map metadata', (done) => {
+    const metadata = {};
+    metadata[SOURCES_FETCH_OPTIONS_KEY] = {
+      'test-source': {
+        headers: {
+          'Authorization': 'foo',
+        },
+      }
+    };
+    store.dispatch(MapActions.updateMetadata(metadata));
+    // mock up the url to call
+    nock('http://example.com')
+      .get('/base/test.geojson')
+      .matchHeader('Authorization', 'foo')
+      .reply(200, JSON.stringify(feature_collection));
+
+    testGeojsonData(done, './test.geojson', 2);
   });
 
   it('adds a geojson feature collection from a relative url', (done) => {

--- a/changelog/v2.6.2.md
+++ b/changelog/v2.6.2.md
@@ -1,0 +1,35 @@
+# 2.6.2
+
+The v2.6.2 release fixes a few bugs and adds a new feature:
+
+## Features
+
+ * Allow specifying the fetch options per source (#932)
+
+An example is:
+
+```
+  map: {
+    metadata: {
+      'bnd-sources-fetch-options': {
+        'foo': {
+          headers: {
+            'Authorization': 'foo'
+          }
+        }
+      }
+    },
+    sources: {
+      'foo': {
+        type: raster',
+        ..
+      },
+    },
+    ..
+```
+
+## Bug fixes
+
+ * addWmsSource should handle an extra ? in the url (#929)
+ * addWmsSource should handle layer projection (#929)
+ * Change the mapbox-gl-style-spec imports (#931)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundlessgeo/sdk",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Boundless Web SDK",
   "scripts": {
     "start": "webpack-dev-server --config webpack-dev-server.config.js --open --open-page 'build/examples'",

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,7 @@
 
 export const LAYER_VERSION_KEY = 'bnd:layer-version';
 export const SOURCE_VERSION_KEY = 'bnd:source-version';
+export const SOURCES_FETCH_OPTIONS_KEY = 'bnd-sources-fetch-options';
 export const TITLE_KEY = 'bnd:title';
 export const TIME_KEY = 'bnd:time';
 export const TIME_START_KEY = 'bnd:start-time';


### PR DESCRIPTION
```
  map: {
    metadata: {
      'bnd-sources-fetch-options': {
        'foo': {
          headers: {
            'Authorization': 'foo'
          }
        }
      }
    },
    sources: {
      'foo': {
        type: raster',
        ..
      },
    },
```