### PR TITLE
There can be both selected and deselected features in the ol event

### DIFF
--- a/__tests__/components/map-drawing.test.js
+++ b/__tests__/components/map-drawing.test.js
@@ -288,10 +288,11 @@ describe('Map component with drawing', () => {
     select.dispatchEvent({
       type: 'select',
       selected: [features[0]],
+      deselected: [features[0]],
     });
 
-    // ensure onFeatureEvent was called.
-    expect(sdk_map.onFeatureEvent).toHaveBeenCalled();
+    // ensure onFeatureEvent was called twice.
+    expect(sdk_map.onFeatureEvent).toHaveBeenCalledTimes(2);
   });
 
   it('handles deselect', () => {

--- a/changelog/v2.6.3.md
+++ b/changelog/v2.6.3.md
@@ -1,0 +1,9 @@
+# 2.6.3
+
+The v2.6.3 release fixes a few bugs:
+
+## Bug fixes
+
+ * Make sure sourceName is set in selected callbacks (#935)
+ * Prevent map component from crashing on tainted canvas for export (#933)
+ * Handle an ol event with both selected and deselected features properly (#937)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundlessgeo/sdk",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Boundless Web SDK",
   "scripts": {
     "start": "webpack-dev-server --config webpack-dev-server.config.js --open --open-page 'build/examples'",

--- a/src/components/map.js
+++ b/src/components/map.js
@@ -1752,7 +1752,8 @@ export class Map extends React.Component {
       select.on('select', (evt) => {
         if (evt.selected.length > 0) {
           this.onFeatureEvent('selected', drawingProps.sourceName, evt.selected);
-        } else if (evt.deselected.length > 0) {
+        }
+        if (evt.deselected.length > 0) {
           this.onFeatureEvent('deselected', drawingProps.sourceName, evt.deselected);
         }
       });


### PR DESCRIPTION
this came up in SDK-1062

If you select feature A, the events will be okay.
If you then select feature B, the selected callback will happen, but the deselected callback for feature A will not happen.

This PR fixes it and adds a test.