### PR TITLE
Release 2.6.5

### DIFF
--- a/changelog/v2.6.5.md
+++ b/changelog/v2.6.5.md
@@ -1,0 +1,11 @@
+# 2.6.5
+
+The v2.6.5 release adds one feature and fixes one bug:
+
+## Feature
+
+ * Allow a legend to be specified in a layer's metadata using the LEGEND_TYPE and LEGEND_CONTENT attributes.
+
+## Bug fixes
+
+ * When checking for queryable layers, first ensure there is a metadata object.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundlessgeo/sdk",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "description": "Boundless Web SDK",
   "scripts": {
     "start": "webpack-dev-server --config webpack-dev-server.config.js --open --open-page 'build/examples'",


### PR DESCRIPTION
# 2.6.5
 The v2.6.5 release adds one feature and fixes one bug:
 ## Feature
  * Allow a legend to be specified in a layer's metadata using the LEGEND_TYPE and LEGEND_CONTENT attributes.
 ## Bug fixes
  * When checking for queryable layers, first ensure there is a metadata object.