### PR TITLE
Review setView to not send the map object

### DIFF
--- a/__tests__/components/mapboxgl.test.js
+++ b/__tests__/components/mapboxgl.test.js
@@ -43,7 +43,36 @@ const createMapMock = () => {
           id: 'foo',
         },
       }];
-    }
+    },
+    getCenter: () => {
+      return {
+        toArray: () => {
+          return [50, 45];
+        }
+      };
+    },
+    getZoom: () => {
+      return 3;
+    },
+    getBearing: () => {
+      return 0;
+    },
+    getBounds: () => {
+      return {
+        getSouthWest: () => {
+          return {
+            lng: -45,
+            lat: -50,
+          };
+        },
+        getNorthEast: () => {
+          return {
+            lng: -25,
+            lat: -20,
+          };
+        }
+      };
+    },
   };
 };
 
@@ -614,35 +643,6 @@ describe('MapboxGL component', () => {
     const map = wrapper.instance().getWrappedInstance();
     // mock up our GL map
     map.map = createMapMock();
-    map.map.getCenter = () => {
-      return {
-        toArray: () => {
-          return [50, 45];
-        }
-      };
-    };
-    map.map.getZoom = () => {
-      return 3;
-    };
-    map.map.getBearing = () => {
-      return 0;
-    };
-    map.map.getBounds = () => {
-      return {
-        getSouthWest: () => {
-          return {
-            lng: -45,
-            lat: -50,
-          };
-        },
-        getNorthEast: () => {
-          return {
-            lng: -25,
-            lat: -20,
-          };
-        }
-      };
-    };
     map.onMapMoveEnd();
     expect(store.getState().mapinfo.extent).toEqual([-45, -50, -25, -20]);
     expect(store.getState().map.center).toEqual([50, 45]);

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jest-cli": "^21.2.1",
     "jest-css-modules": "^1.1.0",
     "jsdoc": "^3.5.4",
-    "mapbox-gl": "^0.44.0",
+    "mapbox-gl": "^0.44.2",
     "marked": "^0.3.6",
     "metalsmith": "^2.3.0",
     "metalsmith-layouts": "^1.8.1",

--- a/src/components/mapboxgl.js
+++ b/src/components/mapboxgl.js
@@ -184,7 +184,19 @@ export class MapboxGL extends React.Component {
   }
 
   onMapMoveEnd() {
-    this.props.setView(this.map, this.props.projection);
+    const center = this.map.getCenter().toArray();
+    const bearing = this.map.getBearing();
+    const zoom = this.map.getZoom();
+
+    const view = {
+      center,
+      zoom,
+      bearing,
+      extent: getMapExtent(this.map),
+      resolution: getResolutionForZoom(zoom, this.props.projection),
+    };
+
+    this.props.setView(view);
   }
 
   onMouseMove(e) {
@@ -496,14 +508,11 @@ function mapDispatchToProps(dispatch) {
   return {
     updateLayer: (layerId, layerConfig) => {
     },
-    setView: (map, projection) => {
-      const center = map.getCenter().toArray();
-      const bearing = map.getBearing();
-      const zoom = map.getZoom();
-      dispatch(setView(center, zoom));
-      dispatch(setBearing(bearing));
-      dispatch(setMapExtent(getMapExtent(map)));
-      dispatch(setResolution(getResolutionForZoom(zoom, projection)));
+    setView: (view) => {
+      dispatch(setView(view.center, view.zoom));
+      dispatch(setBearing(view.bearing));
+      dispatch(setMapExtent(view.extent));
+      dispatch(setResolution(view.resolution));
     },
     setSize: (size, map) => {
       dispatch(setMapSize(size));


### PR DESCRIPTION
Instead of passing the map-object along both Mapbox GL maps
and OpenLayers maps will create an object containing
the relevant data and then pass that to setView.