### PR TITLE
Bug: Do not set HTML context on the component.

### DIFF
--- a/__tests__/components/layer-list.test.js
+++ b/__tests__/components/layer-list.test.js
@@ -4,6 +4,9 @@ import React from 'react';
 import {mount, configure} from 'enzyme';
 import  Adapter from 'enzyme-adapter-react-16';
 
+import {DragDropContext} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+
 import {createStore, combineReducers} from 'redux';
 import {Provider} from 'react-redux';
 
@@ -15,11 +18,13 @@ import {setSourceError} from '@boundlessgeo/sdk/actions/mapinfo';
 
 import {isLayerVisible} from '@boundlessgeo/sdk/util';
 
-import SdkLayerList from '@boundlessgeo/sdk/components/layer-list';
+import LayerList from '@boundlessgeo/sdk/components/layer-list';
 import SdkLayerListItem from  '@boundlessgeo/sdk/components/layer-list-item';
 import {layerListItemTarget} from '@boundlessgeo/sdk/components/layer-list-item';
 
 configure({adapter: new Adapter()});
+
+const SdkLayerList = DragDropContext(HTML5Backend)(LayerList);
 
 class TestLayerListItem extends SdkLayerListItem {
   render() {

--- a/examples/layer-list/app.js
+++ b/examples/layer-list/app.js
@@ -9,7 +9,8 @@ import {createStore, combineReducers} from 'redux';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {DragSource, DropTarget} from 'react-dnd';
+import {DragDropContext, DragSource, DropTarget} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 import {types, layerListItemSource, layerListItemTarget, collect, collectDrop} from '@boundlessgeo/sdk/components/layer-list-item';
 import SdkMap from '@boundlessgeo/sdk/components/map';
 import SdkZoomControl from '@boundlessgeo/sdk/components/map/zoom-control';
@@ -226,13 +227,15 @@ function main() {
     </SdkMap>
   </Provider>, document.getElementById('map'));
 
-  // add some buttons to demo some actions.
+  // Add DND to the LayerList
+  const DragDropLayerList = DragDropContext(HTML5Backend)(SdkLayerList);
+
   ReactDOM.render((
     <div>
       <h3>Try it out</h3>
       <div className='sdk-layerlist'>
         <Provider store={store}>
-          <SdkLayerList layerClass={LayerListItem} />
+          <DragDropLayerList layerClass={LayerListItem} />
         </Provider>
       </div>
     </div>

--- a/examples/wms/app.js
+++ b/examples/wms/app.js
@@ -9,6 +9,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import WMSCapabilitiesFormat from 'ol/format/WMSCapabilities';
+import {DragDropContext} from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 
 import RendererSwitch from '../rendererswitch';
 import SdkZoomControl from '@boundlessgeo/sdk/components/map/zoom-control';
@@ -112,13 +114,16 @@ function main() {
     </RendererSwitch>
   </Provider>, document.getElementById('map'));
 
+  // Add DND to the LayerList
+  const DragDropLayerList = DragDropContext(HTML5Backend)(SdkLayerList);
+
   // add some buttons to demo some actions.
   ReactDOM.render((
     <div>
       <h3>Try it out</h3>
       <h4>Layers</h4>
       <Provider store={store}>
-        <SdkLayerList />
+        <DragDropLayerList />
       </Provider>
       <button onClick={addWMS}>Add WMS Layer</button>
     </div>

--- a/src/components/layer-list.js
+++ b/src/components/layer-list.js
@@ -14,8 +14,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import HTML5Backend from 'react-dnd-html5-backend';
-import {DragDropContext} from 'react-dnd';
 import {LAYERLIST_HIDE_KEY, GROUP_KEY, GROUPS_KEY} from '../constants';
 import {getLayerIndexById, hasSourceError} from '../util';
 import {SdkLayerListItemDD} from './layer-list-item';
@@ -219,7 +217,5 @@ function mapStateToProps(state) {
     sourceErrors: state.mapinfo ? state.mapinfo.sourceErrors : {},
   };
 }
-
-SdkLayerList = DragDropContext(HTML5Backend)(SdkLayerList);
 
 export default connect(mapStateToProps)(SdkLayerList);


### PR DESCRIPTION
According to the react-dnd docs the context should
be set for the entire application.  While developing an app
I found that I could not add other DND targets or sources because the
context was limited to only the layers list.