### PR TITLE
[WIP] Upgrade webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ After this, run the following commands:
 
 `npm install` - install libraries
 
-`npm run build:examples` - build examples from templates
-
 `npm start` - start webpack-dev-server
 
 The last command should open your browser to a page of examples: http://localhost:3000/build/examples

--- a/config/templates/example.html
+++ b/config/templates/example.html
@@ -4,7 +4,7 @@
     <title>{{ title }}</title>
     <meta charset="utf-8">
     {{> icons }}
-    <link rel="stylesheet" type="text/css" href="../sdk.css"/>
+    {{{ sdkCss.tag }}}
     <link rel="stylesheet" type="text/css" href="../examples.css"/>
     {{{ extraHead.local }}}
     {{{ css.tag }}}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.7.4",
   "description": "Boundless Web SDK",
   "scripts": {
-    "start": "webpack-dev-server --config webpack-dev-server.config.js --open --open-page 'build/examples'",
-    "serve": "webpack-dev-server --config webpack-dev-server.config.js",
+    "start": "npm run build:examples && webpack-dev-server --config webpack-dev-server.config.js --open --open-page 'build/examples'",
+    "serve": "npm run build:examples && webpack-dev-server --config webpack-dev-server.config.js --mode development --watch",
     "pretest": "npm run check-docs ; npm run lint",
     "test": "jest",
     "test:watch": "npm test -- --watch",
@@ -26,7 +26,7 @@
     "check-docs": "cd docs && ./doc_checker.sh"
   },
   "devDependencies": {
-    "@mapbox/mapbox-gl-draw": "^1.0.4",
+    "@mapbox/mapbox-gl-draw": "1.0.9",
     "@mapbox/mapbox-gl-draw-static-mode": "^1.0.1",
     "@turf/area": "^5.0.4",
     "@turf/distance": "^5.0.4",
@@ -57,7 +57,6 @@
     "eslint-plugin-jsx-a11y": "^5.0.2",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-react": "^7.1.0",
-    "extract-text-webpack-plugin": "3.0.2",
     "fs-extra": "^4.0.2",
     "handlebars": "^4.0.10",
     "jest": "^20.0.4",
@@ -69,6 +68,7 @@
     "metalsmith": "^2.3.0",
     "metalsmith-layouts": "^1.8.1",
     "metalsmith-rootpath": "^1.0.4",
+    "mini-css-extract-plugin": "^0.5.0",
     "mixin": "^0.2.0",
     "nock": "^9.0.13",
     "node-sass": "^4.5.3",
@@ -85,9 +85,9 @@
     "redux-mock-store": "^1.2.3",
     "sass-loader": "6.0.6",
     "style-loader": "0.19.0",
-    "uglifyjs-webpack-plugin": "1.0.1",
-    "webpack": "3.8.1",
-    "webpack-dev-server": "2.9.3",
+    "terser-webpack-plugin": "^1.2.0",
+    "webpack": "4.28.0",
+    "webpack-dev-server": "^3.1.10",
     "xmldom": "^0.1.27"
   },
   "dependencies": {
@@ -97,7 +97,8 @@
     "prop-types": "^15.5.10",
     "react-docgen": "^2.19.0",
     "redux-saga": "^0.16.0",
-    "uuid": "^3.1.0"
+    "uuid": "^3.1.0",
+    "webpack-cli": "^3.1.2"
   },
   "peerDependencies": {
     "@mapbox/mapbox-gl-draw-static-mode": "^1.0.1",

--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -58,6 +58,9 @@ function augmentExamples(files, metalsmith, done) {
       file.js = {
         tag: `<script src="./${id}.bundle.js"></script>`,
       };
+      file.sdkCss = {
+        tag: `<link rel="stylesheet" href="./${id}.bundle.css">`,
+      };
       const cssFilename = `${id}/app.css`;
       if (cssFilename in files) {
         file.css = {

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const common  = require('./webpack-common');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const Config = require('dotenv').config();
 
 const entry = common.getEntries(true);
@@ -36,7 +36,9 @@ const config = {
     filename: 'build/examples/[name]/[name].bundle.js',
   },
   plugins: [
-    new ExtractTextPlugin('build/examples/sdk.css'),
+    new MiniCssExtractPlugin({
+      filename: "build/examples/[name]/[name].bundle.css",
+    }),
     // Enables Hot Modules Replacement
     new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
@@ -54,16 +56,12 @@ const config = {
         },
       }, {
         test: /\.s?css$/,
-        use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
-          use: ['css-loader', {
-            loader: 'sass-loader',
-            options: {
-              includePaths: ['node_modules'],
-            }
-          }],
-        }),
-
+        use: [MiniCssExtractPlugin.loader, 'css-loader', {
+          loader: 'sass-loader',
+          options: {
+            includePaths: ['node_modules'],
+          }
+        }],
       }
     ],
   },

--- a/webpack-example.config.js
+++ b/webpack-example.config.js
@@ -2,8 +2,7 @@ const webpack = require('webpack');
 const path = require('path');
 const common  = require('./webpack-common');
 const Config = require('dotenv').config();
-
-const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const entry = common.getEntries(false);
 
@@ -22,9 +21,9 @@ module.exports = {
     filename: 'build/hosted/examples/[name]/[name].bundle.js',
   },
   plugins: [
-    new UglifyJSPlugin({
+    new TerserPlugin({
       sourceMap: false,
-      uglifyOptions: {
+      terserOptions: {
         compress: {
           warnings: false,
           comparisons: false,  // don't optimize comparisons


### PR DESCRIPTION
refs SDK-1079

Since webpack-extract-text-plugin is not compatible, we needed to replace it with mini-css-extract-plugin

https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/701