### PR TITLE
Add missing changelog for 2.5.2 release

### DIFF
--- a/changelog/v2.5.2.md
+++ b/changelog/v2.5.2.md
@@ -1,0 +1,8 @@
+# 2.5.2
+
+The v2.5.2 release fixes two bugs:
+
+## Bugs
+
+ * Fixing typo in filter example (#921)
+ * Add condition for a layer without a source in legend context (#922)

--- a/changelog/v2.6.0.md
+++ b/changelog/v2.6.0.md
@@ -4,7 +4,6 @@ The v2.6.0 release replaces redux-thunk with redux-saga, and fixes a few bugs:
 
 ## Bug fixes
 
- * Check for layer source in legend code (#922)
  * Fix min/max zoom handling on layers (#924)
  * Fix getArea measurement (#927)
 


### PR DESCRIPTION
It appeared we did not have release notes for 2.5.2 and we accidentally included a bug fix that was already in 2.5.2 in the 2.6.0 release notes