### PR TITLE
Adding in a new example

### DIFF
--- a/examples/multigeometry/app.css
+++ b/examples/multigeometry/app.css
@@ -1,0 +1,80 @@
+/* Demo how to over ride the default color of the buttons */
+
+button.sdk-btn.blue {
+    background-color: #29728d;
+}
+
+#controls form {
+  font-size: .85rem;
+}
+
+.mapName {
+  font-weight: 400;
+  line-height: 1.25;
+  text-align: left;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+  border: 1px solid transparent;
+  font-size: 1rem;
+  border-radius: .25rem;
+}
+.filter-box {
+  padding: 2rem;
+  background: #fff;
+  color: #444;
+}
+
+.interior {
+  display: table-cell;
+  vertical-align: middle;
+  z-index: 9999;
+  width: 400px;
+}
+.interior .buttons button.sdk-btn {
+  padding: .25rem;
+}
+.label, .value {
+  display: inline-block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.label {
+  width: 80px;;
+}
+.value {
+  width: 250px;
+}
+/* form specific formatting */
+ .form-group {
+   display: flex;
+   flex-direction: row;
+ }
+
+ .form-group label {
+   flex: none;
+   display: block;
+   width: 95px;
+  }
+ .form-group label.right-inline {
+   text-align: right;
+   padding-right: 4px;
+   padding-left: 5px;
+   width: auto;
+ }
+
+ .form-group .input-control {
+   flex: 1 1 auto;
+   display: block;
+   margin-bottom: 4px;
+   margin-top: -4px;
+ }
+
+ .button-control{
+   margin: 5px;
+ }
+ .filter-list{
+   list-style-type: none;
+ }

--- a/examples/multigeometry/app.js
+++ b/examples/multigeometry/app.js
@@ -1,0 +1,92 @@
+/** SDK  showing filters application example.
+ *
+ */
+
+import {createStore, combineReducers} from 'redux';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {Provider} from 'react-redux';
+
+import RendererSwitch from '../rendererswitch';
+import SdkMapReducer from '@boundlessgeo/sdk/reducers/map';
+import * as mapActions from '@boundlessgeo/sdk/actions/map';
+
+import SdkZoomControl from '@boundlessgeo/sdk/components/map/zoom-control';
+import SdkZoomSlider from '@boundlessgeo/sdk/components/map/zoom-slider';
+
+// This will have webpack include all of the SDK styles.
+import '@boundlessgeo/sdk/stylesheet/sdk.scss';
+
+const store = createStore(combineReducers({
+  map: SdkMapReducer,
+}), window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__());
+
+function main() {
+  // Start with a reasonable global view of the map.
+  store.dispatch(mapActions.setView([0, 0], 1));
+
+  // add the OSM source
+  store.dispatch(mapActions.addOsmSource('osm'));
+
+  // and an OSM layer.
+  // Raster layers need not have any paint styles.
+  store.dispatch(mapActions.addLayer({
+    id: 'osm',
+    source: 'osm',
+    type: 'raster',
+  }));
+
+  const loadJson = (sourceName) => {
+    store.dispatch(mapActions.addSource('shapes', {type: 'geojson', data: 'shapes.geojson'}));
+    store.dispatch(mapActions.addLayer({
+      id: 'shapes_fill',
+      source: 'shapes',
+      type: 'fill',
+      paint: {
+        'fill-opacity': 0.7,
+        'fill-color': '#feb24c',
+        'fill-outline-color': '#f03b20',
+      },
+    }));
+    store.dispatch(mapActions.addLayer({
+      id: 'shapes_line',
+      source: 'shapes',
+      type: 'line',
+      paint: {
+        'line-color': '#005500',
+        'line-width': 1,
+      },
+    }));
+    store.dispatch(mapActions.addLayer({
+      id: 'shapes_point',
+      source: 'shapes',
+      type: 'circle',
+      paint: {
+        'circle-color': '#7F0303',
+        'circle-stroke-width': 1,
+        'circle-radius': 5,
+      },
+    }));
+  };
+  loadJson();
+  // place the map on the page.
+  ReactDOM.render(<Provider store={store}>
+    <RendererSwitch>
+      <SdkZoomControl />
+      <SdkZoomSlider />
+    </RendererSwitch>
+  </Provider>, document.getElementById('map'));
+
+  // add some buttons to demo some actions.
+  ReactDOM.render((
+    <div>
+      <Provider store={store}>
+      </Provider>
+    </div>
+  ), document.getElementById('controls'));
+}
+
+
+main();

--- a/examples/multigeometry/index.html
+++ b/examples/multigeometry/index.html
@@ -1,0 +1,10 @@
+---
+layout: example.html
+title: Multiple Geometry types Example
+shortdesc: SDK app testing multiple geometry types 
+docs: >
+  <li>Adding an tiled map</li>
+  <li>Adding an geojson map</li>
+---
+<div id="filter"></div>
+<div id="controls"></div>

--- a/examples/multigeometry/shapes.1.geojson
+++ b/examples/multigeometry/shapes.1.geojson
@@ -1,0 +1,82 @@
+{
+  "type": "FeatureCollection",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "EPSG:3857"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0, 0]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[4e6, -2e6], [8e6, 2e6]]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[4e6, 2e6], [8e6, -2e6]]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[-5e6, -1e6], [-4e6, 1e6], [-3e6, -1e6]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiLineString",
+        "coordinates": [
+          [[-1e6, -7.5e5], [-1e6, 7.5e5]],
+          [[1e6, -7.5e5], [1e6, 7.5e5]],
+          [[-7.5e5, -1e6], [7.5e5, -1e6]],
+          [[-7.5e5, 1e6], [7.5e5, 1e6]]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [[[-5e6, 6e6], [-5e6, 8e6], [-3e6, 8e6], [-3e6, 6e6]]],
+          [[[-2e6, 6e6], [-2e6, 8e6], [0, 8e6], [0, 6e6]]],
+          [[[1e6, 6e6], [1e6, 8e6], [3e6, 8e6], [3e6, 6e6]]]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "GeometryCollection",
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [[-5e6, -5e6], [0, -5e6]]
+          },
+          {
+            "type": "Point",
+            "coordinates": [4e6, -5e6]
+          },
+          {
+            "type": "Polygon",
+            "coordinates": [[[1e6, -6e6], [2e6, -4e6], [3e6, -6e6]]]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/multigeometry/shapes.geojson
+++ b/examples/multigeometry/shapes.geojson
@@ -1,0 +1,82 @@
+{
+  "type": "FeatureCollection",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "EPSG:3857"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [0, 0]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[4e6, -2e6], [8e6, 2e6]]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [[4e6, 2e6], [8e6, -2e6]]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[[-5e6, -1e6], [-4e6, 1e6], [-3e6, -1e6], [-5e6, -1e6]]]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiLineString",
+        "coordinates": [
+          [[-1e6, -7.5e5], [-1e6, 7.5e5]],
+          [[1e6, -7.5e5], [1e6, 7.5e5]],
+          [[-7.5e5, -1e6], [7.5e5, -1e6]],
+          [[-7.5e5, 1e6], [7.5e5, 1e6]]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+          [[[-5e6, 6e6], [-5e6, 8e6], [-3e6, 8e6], [-3e6, 6e6], [-5e6, 6e6]]],
+          [[[-2e6, 6e6], [-2e6, 8e6], [0, 8e6], [0, 6e6], [-2e6, 6e6]]],
+          [[[1e6, 6e6], [1e6, 8e6], [3e6, 8e6], [3e6, 6e6], [1e6, 6e6]]]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "GeometryCollection",
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [[-5e6, -5e6], [0, -5e6]]
+          },
+          {
+            "type": "Point",
+            "coordinates": [4e6, -5e6]
+          },
+          {
+            "type": "Polygon",
+            "coordinates": [[[1e6, -6e6], [2e6, -4e6], [3e6, -6e6], [1e6, -6e6]]]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Started to check on #791 turns out support exists so I wanted to make an example to prove it.  Example is base on Openlayers example https://openlayers.org/en/latest/examples/geojson.html .  Found that Openlayers allows unclosed polygons while SDK does not.  Also noticed SDK doesn't handle Points inside of GeometryCollections.  