### PR TITLE
Fixing a deprecated function used in node script

### DIFF
--- a/tasks/build-examples.js
+++ b/tasks/build-examples.js
@@ -35,7 +35,7 @@ function createIndex(files, metalsmith, done) {
     layout: 'index.html',
     title: 'Boundless SDK Examples',
     pageTitle: 'Boundless SDK in action',
-    contents: new Buffer(index),
+    contents: Buffer.from(index),
     mode: '0644',
   };
 }


### PR DESCRIPTION
A error is thrown when running build:example script because calling `new Buffer` is deprecated in node.  `    contents: new Buffer(index) `

```(node:15707) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.```

Moved to new `Buffer.from`